### PR TITLE
ci(commitlint): add commitlint action to github workflow

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,11 @@
+name: Lint Commit Messages
+on: [pull_request]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v4.1.12

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,5 @@
+/* eslint-disable import/no-extraneous-dependencies */
+
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+}


### PR DESCRIPTION
# Descriptions
This commit is to add a new GitHub workflow to validate:
- If the commits on the PR respect the commit convention. [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) 

## How to use it
We are using config-conventional based on the angular convention [config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)

#### Rule type example

  ```
  [
    'build',
    'ci',
    'docs',
    'feat',
    'fix',
    'perf',
    'refactor',
    'revert',
    'style',
    'test'
  ]
  ```

```sh
echo "foo: some message" # fails
echo "fix: some message" # passes
```
