### PR TITLE
fix: solve issue with setup command

### DIFF
--- a/tvm/cli.py
+++ b/tvm/cli.py
@@ -254,6 +254,9 @@ def install_venv() -> None:
         os.symlink(f'{TVM_PATH}/tutor_switcher', venv_tutor)
     except FileExistsError:
         pass
+    except PermissionError:
+        click.echo(
+            click.style('To set up tvm local is necessary that tvm had been installed in a virtualenv.', fg='red'))
     else:
         click.echo(click.style(
             'Re-activate your virtualenv for changes to take effect', fg='yellow'))
@@ -265,9 +268,10 @@ def install_global(make_global) -> None:
     """Make the switcher file to anyone in the system."""
     setup_tvm()
     set_switch_from_file()
-    install_venv()
 
-    if make_global:
+    if not make_global:
+        install_venv()
+    else:
         try:
             os.symlink(f'{TVM_PATH}/tutor_switcher', '/usr/local/bin/tutor')
         except PermissionError:


### PR DESCRIPTION
# Description
This pr is to fix something that I think is an issue

# How to trigger it
**Without a virtualenv**
```bash
pip install git+https://github.com/eduNEXT/tvm.git
tvm setup -g
```
**Error:**
```bash
PermissionError: [Errno 13] Permission denied: '<path>/.tvm/tutor_switcher' -> '/usr/bin/tutor'
```

I don't know if we expected it and is normal, but I think that the setup -g shouldn't need a virtualenv.