### PR TITLE
fix: solve bug with tvm project env

### DIFF
--- a/tvm/templates/tvm_activate.py
+++ b/tvm/templates/tvm_activate.py
@@ -47,7 +47,7 @@ tvmoff () {
 }
 # unset irrelevant variables
 tvmoff nondestructive
-TVM_PROJECT_ENV="$PWD/.tvm"
+TVM_PROJECT_ENV="{{ tutor_root }}/.tvm"
 export TVM_PROJECT_ENV
 _TVM_OLD_VIRTUAL_PATH="$PATH"
 PATH="$TVM_PROJECT_ENV/bin:$PATH"


### PR DESCRIPTION
# Description
This PR is to fix the bug in projects when someone tries to enable .tvm environment from another path.

# Before
```bash
mkdir test && cd test
tvm project init
cd ..
source test/.tvm/bin/activate
which tutor # This response the global tutor (this is the bug)
```

# Now
```bash
mkdir test && cd test
tvm project init
cd ..
source test/.tvm/bin/activate
which tutor # This response the __tutor_root_path__/.tvm/bin/tutor
```