### PR TITLE
feat: add command tvm plugins install

### DIFF
--- a/tvm/cli.py
+++ b/tvm/cli.py
@@ -121,6 +121,7 @@ def setup_tvm():
 
 
 def setup_version_virtualenv(version=None) -> None:
+    """Create virtualenv and install tutor cloned."""
     # Create virtualenv
     subprocess.run(f'cd {TVM_PATH}/{version}; virtualenv venv',
                    shell=True, check=True,

--- a/tvm/cli.py
+++ b/tvm/cli.py
@@ -229,6 +229,14 @@ def get_active_version() -> str:
     return 'No active version installed'
 
 
+def get_project_version(tvm_project_path) -> str:
+    """Read the current active version from the json/bash switcher."""
+    info_file_path = f'{tvm_project_path}/config.json'
+    with open(info_file_path, 'r', encoding='utf-8') as info_file:
+        data = json.load(info_file)
+    return data.get('version')
+
+
 def set_active_version(version) -> None:
     """Set the active version in the json to VERSION."""
     info_file_path = f'{TVM_PATH}/current_bin.json'
@@ -423,6 +431,17 @@ def init(name: str = None, version: str = None):
         raise click.UsageError('There is already a project initiated.') from IndexError
 
 
+@click.command(name="install", context_settings={"ignore_unknown_options": True})
+@click.argument('options', nargs=-1, type=click.UNPROCESSED)
+def install_plugin(options):
+    """Use the package installer pip in current tutor version."""
+    options = list(options)
+    options.insert(0, "install")
+    if "TVM_PROJECT_ENV" in os.environ:
+        run_on_tutor_venv('pip', options, version=get_project_version(os.environ.get("TVM_PROJECT_ENV")))
+    run_on_tutor_venv('pip', options)
+
+
 if __name__ == "__main__":
     main()
 
@@ -435,3 +454,4 @@ cli.add_command(projects)
 projects.add_command(init)
 cli.add_command(plugins)
 plugins.add_command(list_plugins)
+plugins.add_command(install_plugin)

--- a/tvm/templates/tvm_activate.py
+++ b/tvm/templates/tvm_activate.py
@@ -11,6 +11,10 @@ fi
 tvmoff () {
     # reset old environment variables
     # ! [ -z ${VAR+_} ] returns true if VAR is declared at all
+    if ! [ -z "${TVM_PROJECT_ENV:+_}" ] ; then
+        unset TVM_PROJECT_ENV
+    fi
+
     if ! [ -z "${_TVM_OLD_VIRTUAL_PATH:+_}" ] ; then
         PATH="$_TVM_OLD_VIRTUAL_PATH"
         export PATH


### PR DESCRIPTION
# Description
This PR is to add a command to install "plugins" or "pip packages".

# How to use
You should call the command `tvm plugins install <package || path || repository>`
```bash
tvm plugins install /path/to/my/local/package
tvm plugins install git+https://github.com/eduNEXT/tutor-contrib-edunext-distro.git
tvm plugins install tutor-mfe
```
This command can be exec global or with a tvm project enable
```bash
source .tvm/bin/activate
tvm plugins install /path/to/my/local/package
tvm plugins install git+https://github.com/eduNEXT/tutor-contrib-edunext-distro.git
tvm plugins install tutor-mfe
```

# How to test
```bash
# 1. with a global version installed
tvm plugins install tutor-mfe

# create a new project
mkdir test && cd test
tvm project init
source .tvm/bin/activate
tvm plugins list # you should see the mfe plugin installed only in global
```
