### PR TITLE
feat: add tvm config commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ To switch between tutor versions you should call
 tvm use v<TUTOR_VERSION_INSTALLED>
 ```
 
+## Setting tutor root variables
+To set TUTOR_ROOT and TUTOR_PLUGINS_ROOT variables you should call
+
+```bash
+# TUTOR_ROOT=Current Working Directory and TUTOR_PLUGINS_ROOT=TUTOR_ROOT/plugins
+tvm config save .
+
+# TUTOR_ROOT=/home/user/tutor-test and TUTOR_PLUGINS_ROOT=TUTOR_ROOT/plugins
+tvm config save /home/user/tutor-test
+```
+If you want set a different TUTOR_PLUGINS_ROOT you should use
+the option tvm `config save . --plugins-root="PATH"`
+
 ## Installing a plugin in the current tutor version
 To install a tutor plugin in the current tutor version you should call
 

--- a/tvm/templates/tutor_switcher.py
+++ b/tvm/templates/tutor_switcher.py
@@ -3,16 +3,13 @@ from jinja2 import Template
 
 TEMPLATE = '''
 {% if tutor_root %}
-echo -e "Using the \033[1;32m{{ config_name }}\033[0m config" >&2
 export TUTOR_ROOT={{ tutor_root }}
-export TUTOR_PLUGINS_ROOT={{ tutor_root }}/inline_plugins
-{% else %}
-echo -e "You have not selected any config. Tutor will use the global default \033[1;31m~.local/share/tutor\033[0m"
+export TUTOR_PLUGINS_ROOT={{ tutor_plugins_root }}
 {% endif %}
 {% if version %}
 {{ tvm }}/{{ version }}/venv/bin/tutor $@
 {% else %}
-echo "You need to select a tutor active version at first. Run 'stack tvm use <VERSION>'"
+echo "You need to select a tutor active version at first. Run 'tvm use <VERSION>'"
 {% endif %}
 '''
 


### PR DESCRIPTION
# Description
This PR is to add `tvm config` command that permits set tutor variables.

`tvm config save`: for set TUTOR_ROOT and TUTOR_PLUGINS_ROOT variables in tutor_switcher
`tvm config clear`: for clear TUTOR_ROOT and TUTOR_PLUGINS_ROOT variables from tutor_switcher.

# How to test
```bash
pip install git+https://github.com/eduNEXT/tvm.git@set-global-tutor-root-variables
tvm install v12.2.0
tvm use v12.2.0

mkdir test && cd test
tutor config printroot # /home/your_user/.local/share/tutor
tutor plugins printroot # /home/your_user/.local/share/tutor-plugins

tvm config save .
tutor config printroot # current working directory
tutor plugins printroot # current working directory/plugins

tvm config clear
tutor config printroot # /home/your_user/.local/share/tutor
tutor plugins printroot # /home/your_user/.local/share/tutor-plugins
```