### PR TITLE
feat: add plugins uninstall command

### DIFF
--- a/tvm/cli.py
+++ b/tvm/cli.py
@@ -495,6 +495,15 @@ def install_plugin(options):
     else:
         run_on_tutor_venv('pip', options)
 
+@click.command(name="uninstall", context_settings={"ignore_unknown_options": True})
+@click.argument('options', nargs=-1, type=click.UNPROCESSED)
+def uninstall_plugin(options):
+    """Use the package installer pip in current tutor version."""
+    options = list(options)
+    options.insert(0,"uninstall")
+    options.append("-y")
+    click.echo(run_on_tutor_venv('pip', options))
+
 
 @click.group(
     name="config",
@@ -561,6 +570,7 @@ projects.add_command(init)
 cli.add_command(plugins)
 plugins.add_command(list_plugins)
 plugins.add_command(install_plugin)
+plugins.add_command(uninstall_plugin)
 cli.add_command(config)
 config.add_command(save)
 config.add_command(clear)

--- a/tvm/cli.py
+++ b/tvm/cli.py
@@ -495,12 +495,13 @@ def install_plugin(options):
     else:
         run_on_tutor_venv('pip', options)
 
+
 @click.command(name="uninstall", context_settings={"ignore_unknown_options": True})
 @click.argument('options', nargs=-1, type=click.UNPROCESSED)
 def uninstall_plugin(options):
     """Use the package installer pip in current tutor version."""
     options = list(options)
-    options.insert(0,"uninstall")
+    options.insert(0, "uninstall")
     options.append("-y")
     click.echo(run_on_tutor_venv('pip', options))
 


### PR DESCRIPTION
### Description

This PR is to add `tvm plugins uninstall ` command to uninstall plugins.

### How to use
You should call the command tvm plugins install <package || path || repository>

```
tvm plugins uninstall /path/to/my/local/package
tvm plugins uninstall tutor-contrib-edunext-distro
```

This command can be exec global or with a tvm project enable

```
source .tvm/bin/activate
tvm plugins uninstall /path/to/my/local/package
tvm plugins uninstall git+https://github.com/eduNEXT/tutor-contrib-edunext-distro.git
```

### How to test it

```
pip install git+https://github.com/eduNEXT/tvm.git@jhp/add-command-plugins-uninstall
tvm install v12.2.0
tvm use v12.2.0
tvm plugins install git+https://github.com/eduNEXT/tutor-contrib-edunext-distro.git
tvm plugins list
tvm plugins uninstall tutor-contrib-edunext-distro
tvm plugins list
```


