### PR TITLE
perf: tvm migrate commands

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,12 +29,6 @@ def test_should_fail_if_version_does_not_exist():
     assert 'Could not find target: v0.0.99' in result.stdout
 
 
-def test_should_fail_if_version_is_not_installed():
-    runner = CliRunner()
-    result = runner.invoke(uninstall, ["v0.0.99"])
-    assert 'Nothing to uninstall' in result.stdout
-
-
 def test_should_return_all_tvm_project_commands():
     runner = CliRunner()
     result = runner.invoke(projects)

--- a/tests/version_manager/application/test_tutor_plugin_installer.py
+++ b/tests/version_manager/application/test_tutor_plugin_installer.py
@@ -1,0 +1,32 @@
+import pytest
+
+from tests.version_manager.infrastructure.version_manager_in_memory_repository import (
+    VersionManagerInMemoryRepository,
+)
+from tvm.version_manager.application.tutor_plugin_installer import TutorPluginInstaller
+
+
+def test_should_install_the_tutor_plugin():
+    # Given
+    options = ["tutor-mfe"]
+    repository = VersionManagerInMemoryRepository()
+
+    # When
+    installer = TutorPluginInstaller(repository=repository)
+    installer(options)
+
+    # Then
+    assert options in repository.PLUGINS_INSTALLED
+
+
+def test_should_fail_if_not_add_tutor_plugin():
+    # Given
+    options = []
+    repository = VersionManagerInMemoryRepository()
+
+    # When
+    installer = TutorPluginInstaller(repository=repository)
+
+    # Then
+    with pytest.raises(Exception) as format_err:
+        installer(options)

--- a/tests/version_manager/application/test_tutor_plugin_uninstaller.py
+++ b/tests/version_manager/application/test_tutor_plugin_uninstaller.py
@@ -1,0 +1,34 @@
+import pytest
+
+from tests.version_manager.infrastructure.version_manager_in_memory_repository import (
+    VersionManagerInMemoryRepository,
+)
+from tvm.version_manager.application.tutor_plugin_uninstaller import (
+    TutorPluginUninstaller,
+)
+
+
+def test_should_uninstall_the_tutor_plugin():
+    # Given
+    options = "codejail"
+    repository = VersionManagerInMemoryRepository()
+
+    # When
+    uninstaller = TutorPluginUninstaller(repository=repository)
+    uninstaller(options)
+
+    # Then
+    assert options not in repository.VERSIONS_INSTALLED
+
+
+def test_should_fail_if_not_add_tutor_plugin():
+    # Given
+    options = "tutor-mfe"
+    repository = VersionManagerInMemoryRepository()
+
+    # When
+    uninstaller = TutorPluginUninstaller(repository=repository)
+
+    # Then
+    with pytest.raises(Exception) as format_err:
+        uninstaller(options)

--- a/tests/version_manager/application/test_tutor_version_enabler.py
+++ b/tests/version_manager/application/test_tutor_version_enabler.py
@@ -1,0 +1,17 @@
+from tests.version_manager.infrastructure.version_manager_in_memory_repository import (
+    VersionManagerInMemoryRepository,
+)
+from tvm.version_manager.application.tutor_version_enabler import TutorVersionEnabler
+
+
+def test_should_enabler_the_tutor_version():
+    # Given
+    version = "v1.2.3"
+    repository = VersionManagerInMemoryRepository()
+
+    # When
+    enabler = TutorVersionEnabler(repository=repository)
+    enabler(version=version)
+
+    # Then
+    assert version in repository.VERSIONS_INSTALLED

--- a/tests/version_manager/application/test_tutor_version_installer.py
+++ b/tests/version_manager/application/test_tutor_version_installer.py
@@ -1,0 +1,37 @@
+import pytest
+
+from tests.version_manager.infrastructure.version_manager_in_memory_repository import (
+    VersionManagerInMemoryRepository,
+)
+from tvm.version_manager.application.tutor_version_installer import (
+    TutorVersionInstaller,
+)
+from tvm.version_manager.domain.tutor_version_format_error import (
+    TutorVersionFormatError,
+)
+
+
+def test_should_fail_if_version_format_is_not_valid():
+    # Given
+    version = "v123"
+    repository = VersionManagerInMemoryRepository()
+
+    # When
+    installer = TutorVersionInstaller(repository=repository)
+
+    # Then
+    with pytest.raises(TutorVersionFormatError) as format_err:
+        installer(version=version)
+
+
+def test_should_install_the_tutor_version():
+    # Given
+    version = "v1.2.3"
+    repository = VersionManagerInMemoryRepository()
+
+    # When
+    installer = TutorVersionInstaller(repository=repository)
+    installer(version=version)
+
+    # Then
+    assert version in repository.VERSIONS_INSTALLED

--- a/tests/version_manager/application/test_tutor_version_lister.py
+++ b/tests/version_manager/application/test_tutor_version_lister.py
@@ -1,0 +1,19 @@
+from tests.version_manager.infrastructure.version_manager_in_memory_repository import (
+    VersionManagerInMemoryRepository,
+)
+from tvm.version_manager.application.tutor_vesion_lister import TutorVersionLister
+
+
+def test_should_list_tutor_versions():
+    # Given
+    limit = 10
+    list_versions = []
+    for version in range(limit):
+        list_versions.append(f"v1.2.{version}")
+    repository = VersionManagerInMemoryRepository()
+
+    # When
+    lister = TutorVersionLister(repository=repository)
+
+    # Then
+    assert list_versions == lister(limit=limit)

--- a/tests/version_manager/application/test_tutor_version_uninstaller.py
+++ b/tests/version_manager/application/test_tutor_version_uninstaller.py
@@ -1,0 +1,19 @@
+from tests.version_manager.infrastructure.version_manager_in_memory_repository import (
+    VersionManagerInMemoryRepository,
+)
+from tvm.version_manager.application.tutor_version_uninstaller import (
+    TutorVersionUninstaller,
+)
+
+
+def test_should_uninstall_the_tutor_version():
+    # Given
+    version = "v1.2.4"
+    repository = VersionManagerInMemoryRepository()
+
+    # When
+    uninstaller = TutorVersionUninstaller(repository=repository)
+    uninstaller(version=version)
+
+    # Then
+    assert version not in repository.VERSIONS_INSTALLED

--- a/tests/version_manager/infrastructure/version_manager_in_memory_repository.py
+++ b/tests/version_manager/infrastructure/version_manager_in_memory_repository.py
@@ -1,0 +1,54 @@
+from typing import List, Optional
+
+from tvm.version_manager.domain.tutor_version import TutorVersion
+from tvm.version_manager.domain.version_manager_repository import (
+    VersionManagerRepository,
+)
+
+
+class VersionManagerInMemoryRepository(VersionManagerRepository):
+    VERSIONS_INSTALLED = ["v1.2.4"]
+    PLUGINS_INSTALLED = ["codejail"]
+    LIST_VERSIONS = []
+    for version in range(20):
+        LIST_VERSIONS.append(f"v1.2.{version}")
+
+    def list_versions(self, limit: int) -> List[TutorVersion]:
+        return self.LIST_VERSIONS[0:limit]
+
+    @staticmethod
+    def local_versions(tvm_path: str) -> List[TutorVersion]:
+        pass
+
+    @staticmethod
+    def current_version(tvm_path: str) -> List[TutorVersion]:
+        pass
+
+    def install_version(self, version: TutorVersion) -> None:
+        self.VERSIONS_INSTALLED.append(version)
+
+    def find_version(self, version: TutorVersion) -> Optional[TutorVersion]:
+        return version if version in self.VERSIONS_INSTALLED else None
+
+    def uninstall_version(self, version: TutorVersion) -> None:
+        if version in self.VERSIONS_INSTALLED:
+            self.VERSIONS_INSTALLED.clear()
+
+    def use_version(self, version: TutorVersion) -> None:
+        self.VERSIONS_INSTALLED[0] = version
+
+    @staticmethod
+    def version_is_installed(version: str) -> None:
+        pass
+
+    def install_plugin(self, options: List) -> None:
+        if options:
+            self.PLUGINS_INSTALLED.append(options)
+        else:
+            raise Exception(f"Error running venv commands: None")
+
+    def uninstall_plugin(self, options: List) -> None:
+        if options == self.PLUGINS_INSTALLED[0]:
+            self.PLUGINS_INSTALLED.clear()
+        else:
+            raise Exception(f"Error running venv commands: None")

--- a/tvm/cli.py
+++ b/tvm/cli.py
@@ -22,6 +22,8 @@ from click.shell_completion import CompletionItem
 from tvm import __version__
 from tvm.templates.tutor_switcher import TUTOR_SWITCHER_TEMPLATE
 from tvm.templates.tvm_activate import TVM_ACTIVATE_SCRIPT
+from tvm.version_manager.application.tutor_vesion_lister import TutorVersionLister
+from tvm.version_manager.infrastructure.version_manager_git_repository import VersionManagerGitRepository
 
 VERSIONS_URL = "https://api.github.com/repos/overhangio/tutor/tags"
 TVM_PATH = pathlib.Path.home() / '.tvm'
@@ -137,8 +139,38 @@ def setup_version_virtualenv(version=None) -> None:
 
 
 @click.command(name="list")
-@click.option('-l', '--limit', default=10, help='number of `latest versions` to list')
+@click.option("-l", "--limit", default=10, help="number of `latest versions` to list")
 def list_versions(limit: int):
+    repository = VersionManagerGitRepository()
+    lister = TutorVersionLister(repository=repository)
+    version_names = lister()
+    version_names = sorted(version_names, reverse=True, key=LooseVersion)
+    local_versions = repository.get_tutor_local_versions()
+    global_active = repository.get_active_tutor_version()
+    project_version = None
+    if "TVM_PROJECT_ENV" in os.environ:
+        project_version = repository.get_project_tutor_version(
+            os.environ.get("TVM_PROJECT_ENV")
+        )
+    for name in version_names:
+        color = "yellow"
+        if name in local_versions:
+            color = "green"
+        if name == global_active:
+            if project_version:
+                color = "blue"
+                name = f"{name} (global)"
+            else:
+                name = f"{name} (active)"
+        if project_version and project_version == name:
+            name = f"{name} (active)"
+        click.echo(click.style(name, fg=color))
+
+
+
+@click.command(name="list")
+@click.option('-l', '--limit', default=10, help='number of `latest versions` to list')
+def list_versions_backup(limit: int):
     """
     Get all the versions from github.
 

--- a/tvm/cli.py
+++ b/tvm/cli.py
@@ -177,7 +177,6 @@ def list_versions(limit: int):
         click.echo(click.style(name, fg=color))
 
 
-
 @click.command(name="list")
 @click.option('-l', '--limit', default=10, help='number of `latest versions` to list')
 def list_versions_backup(limit: int):
@@ -520,12 +519,12 @@ def install_plugin(options):
 def uninstall_plugin(options):
     """Use the package installer pip in current tutor version."""
     repository = VersionManagerGitRepository()
-    uninstaller =TutorPluginUninstaller(repository=repository)
+    uninstaller = TutorPluginUninstaller(repository=repository)
     options = list(options)
     options.insert(0, "uninstall")
     options.append("-y")
     uninstaller(options)
-    
+
 
 @click.group(
     name="config",

--- a/tvm/cli.py
+++ b/tvm/cli.py
@@ -152,7 +152,7 @@ def list_versions(limit: int):
     """
     repository = VersionManagerGitRepository()
     lister = TutorVersionLister(repository=repository)
-    version_names = lister()
+    version_names = lister(limit=limit)
     version_names = sorted(version_names, reverse=True, key=LooseVersion)
     local_versions = repository.local_versions(TVM_PATH)
     global_active = repository.current_version(TVM_PATH)

--- a/tvm/cli.py
+++ b/tvm/cli.py
@@ -141,17 +141,21 @@ def setup_version_virtualenv(version=None) -> None:
 @click.command(name="list")
 @click.option("-l", "--limit", default=10, help="number of `latest versions` to list")
 def list_versions(limit: int):
+    """
+    Get all the versions from github.
+
+    Print and mark the both the installed ones and the current.
+    """
     repository = VersionManagerGitRepository()
     lister = TutorVersionLister(repository=repository)
     version_names = lister()
     version_names = sorted(version_names, reverse=True, key=LooseVersion)
-    local_versions = repository.get_tutor_local_versions()
-    global_active = repository.get_active_tutor_version()
+    local_versions = repository.local_versions(TVM_PATH)
+    global_active = repository.current_version(TVM_PATH)
     project_version = None
+
     if "TVM_PROJECT_ENV" in os.environ:
-        project_version = repository.get_project_tutor_version(
-            os.environ.get("TVM_PROJECT_ENV")
-        )
+        project_version = get_project_version(os.environ.get("TVM_PROJECT_ENV"))
     for name in version_names:
         color = "yellow"
         if name in local_versions:

--- a/tvm/cli.py
+++ b/tvm/cli.py
@@ -525,8 +525,7 @@ def uninstall_plugin(options):
     options.insert(0, "uninstall")
     options.append("-y")
     uninstaller(options)
-    # click.echo(run_on_tutor_venv('pip', options))
-
+    
 
 @click.group(
     name="config",

--- a/tvm/cli.py
+++ b/tvm/cli.py
@@ -20,6 +20,8 @@ from click.shell_completion import CompletionItem
 from tvm import __version__
 from tvm.templates.tutor_switcher import TUTOR_SWITCHER_TEMPLATE
 from tvm.templates.tvm_activate import TVM_ACTIVATE_SCRIPT
+from tvm.version_manager.application.tutor_plugin_installer import TutorPluginInstaller
+from tvm.version_manager.application.tutor_plugin_uninstaller import TutorPluginUninstaller
 from tvm.version_manager.application.tutor_version_enabler import TutorVersionEnabler
 from tvm.version_manager.application.tutor_version_finder import TutorVersionFinder
 from tvm.version_manager.application.tutor_version_installer import TutorVersionInstaller
@@ -508,17 +510,22 @@ def install_plugin(options):
     if "TVM_PROJECT_ENV" in os.environ:
         run_on_tutor_venv('pip', options, version=get_project_version(os.environ.get("TVM_PROJECT_ENV")))
     else:
-        run_on_tutor_venv('pip', options)
+        repository = VersionManagerGitRepository()
+        installer = TutorPluginInstaller(repository=repository)
+        installer(options)
 
 
 @click.command(name="uninstall", context_settings={"ignore_unknown_options": True})
 @click.argument('options', nargs=-1, type=click.UNPROCESSED)
 def uninstall_plugin(options):
     """Use the package installer pip in current tutor version."""
+    repository = VersionManagerGitRepository()
+    uninstaller =TutorPluginUninstaller(repository=repository)
     options = list(options)
     options.insert(0, "uninstall")
     options.append("-y")
-    click.echo(run_on_tutor_venv('pip', options))
+    uninstaller(options)
+    # click.echo(run_on_tutor_venv('pip', options))
 
 
 @click.group(

--- a/tvm/version_manager/__init__.py
+++ b/tvm/version_manager/__init__.py
@@ -1,0 +1,1 @@
+"""Version manager init."""

--- a/tvm/version_manager/application/__init__.py
+++ b/tvm/version_manager/application/__init__.py
@@ -1,0 +1,1 @@
+"""Application init."""

--- a/tvm/version_manager/application/tutor_plugin_installer.py
+++ b/tvm/version_manager/application/tutor_plugin_installer.py
@@ -1,0 +1,10 @@
+from tvm.version_manager.domain.tutor_version import TutorVersion
+from tvm.version_manager.domain.version_manager_repository import VersionManagerRepository
+
+
+class TutorPluginInstaller:
+    def __init__(self, repository: VersionManagerRepository) -> None:
+        self.repository = repository
+
+    def __call__(self, options) -> None:
+        self.repository.install_plugin(options)

--- a/tvm/version_manager/application/tutor_plugin_installer.py
+++ b/tvm/version_manager/application/tutor_plugin_installer.py
@@ -1,9 +1,14 @@
+"""Tutor plugin installer application."""
 from tvm.version_manager.domain.version_manager_repository import VersionManagerRepository
 
 
 class TutorPluginInstaller:
+    """Tutor plugin installer for version manager."""
+
     def __init__(self, repository: VersionManagerRepository) -> None:
+        """init."""
         self.repository = repository
 
     def __call__(self, options) -> None:
+        """call."""
         self.repository.install_plugin(options)

--- a/tvm/version_manager/application/tutor_plugin_installer.py
+++ b/tvm/version_manager/application/tutor_plugin_installer.py
@@ -1,4 +1,3 @@
-from tvm.version_manager.domain.tutor_version import TutorVersion
 from tvm.version_manager.domain.version_manager_repository import VersionManagerRepository
 
 

--- a/tvm/version_manager/application/tutor_plugin_uninstaller.py
+++ b/tvm/version_manager/application/tutor_plugin_uninstaller.py
@@ -1,0 +1,10 @@
+from tvm.version_manager.domain.tutor_version import TutorVersion
+from tvm.version_manager.domain.version_manager_repository import VersionManagerRepository
+
+
+class TutorPluginUninstaller:
+    def __init__(self, repository: VersionManagerRepository) -> None:
+        self.repository = repository
+
+    def __call__(self, options) -> None:
+        self.repository.uninstall_plugin(options)

--- a/tvm/version_manager/application/tutor_plugin_uninstaller.py
+++ b/tvm/version_manager/application/tutor_plugin_uninstaller.py
@@ -1,10 +1,14 @@
-from tvm.version_manager.domain.tutor_version import TutorVersion
+"""Tutor plugin uninstaller application."""
 from tvm.version_manager.domain.version_manager_repository import VersionManagerRepository
 
 
 class TutorPluginUninstaller:
+    """Tutor plugin uninstaller for version manager."""
+
     def __init__(self, repository: VersionManagerRepository) -> None:
+        """init."""
         self.repository = repository
 
     def __call__(self, options) -> None:
+        """call."""
         self.repository.uninstall_plugin(options)

--- a/tvm/version_manager/application/tutor_version_enabler.py
+++ b/tvm/version_manager/application/tutor_version_enabler.py
@@ -1,11 +1,16 @@
+"""Tutor version enabler application."""
 from tvm.version_manager.domain.tutor_version import TutorVersion
 from tvm.version_manager.domain.version_manager_repository import VersionManagerRepository
 
 
 class TutorVersionEnabler:
+    """Tutor version enabler for version manager."""
+
     def __init__(self, repository: VersionManagerRepository) -> None:
+        """init."""
         self.repository = repository
 
     def __call__(self, version: str) -> None:
+        """call."""
         version = TutorVersion(version)
         self.repository.use_version(version)

--- a/tvm/version_manager/application/tutor_version_enabler.py
+++ b/tvm/version_manager/application/tutor_version_enabler.py
@@ -1,0 +1,11 @@
+from tvm.version_manager.domain.tutor_version import TutorVersion
+from tvm.version_manager.domain.version_manager_repository import VersionManagerRepository
+
+
+class TutorVersionEnabler:
+    def __init__(self, repository: VersionManagerRepository) -> None:
+        self.repository = repository
+
+    def __call__(self, version: str) -> None:
+        version = TutorVersion(version)
+        self.repository.use_version(version)

--- a/tvm/version_manager/application/tutor_version_finder.py
+++ b/tvm/version_manager/application/tutor_version_finder.py
@@ -1,0 +1,11 @@
+from tvm.version_manager.domain.tutor_version import TutorVersion
+from tvm.version_manager.domain.version_manager_repository import VersionManagerRepository
+
+
+class TutorVersionFinder:
+    def __init__(self, repository: VersionManagerRepository):
+        self.repository = repository
+
+    def __call__(self, version: str) -> TutorVersion:
+        version = TutorVersion(version)
+        return self.repository.find_version(version=version)

--- a/tvm/version_manager/application/tutor_version_finder.py
+++ b/tvm/version_manager/application/tutor_version_finder.py
@@ -1,11 +1,16 @@
+"""Tutor version finder application."""
 from tvm.version_manager.domain.tutor_version import TutorVersion
 from tvm.version_manager.domain.version_manager_repository import VersionManagerRepository
 
 
 class TutorVersionFinder:
+    """Tutor version finder for version manager."""
+
     def __init__(self, repository: VersionManagerRepository):
+        """init."""
         self.repository = repository
 
     def __call__(self, version: str) -> TutorVersion:
+        """call."""
         version = TutorVersion(version)
         return self.repository.find_version(version=version)

--- a/tvm/version_manager/application/tutor_version_installer.py
+++ b/tvm/version_manager/application/tutor_version_installer.py
@@ -1,11 +1,16 @@
+"""Tutor version installer application."""
 from tvm.version_manager.domain.tutor_version import TutorVersion
 from tvm.version_manager.domain.version_manager_repository import VersionManagerRepository
 
 
 class TutorVersionInstaller:
+    """Tutor version installer for version manager."""
+
     def __init__(self, repository: VersionManagerRepository) -> None:
+        """init."""
         self.repository = repository
 
     def __call__(self, version: str) -> None:
+        """call."""
         version = TutorVersion(version)
         self.repository.install_version(version=version)

--- a/tvm/version_manager/application/tutor_version_installer.py
+++ b/tvm/version_manager/application/tutor_version_installer.py
@@ -1,0 +1,11 @@
+from tvm.version_manager.domain.tutor_version import TutorVersion
+from tvm.version_manager.domain.version_manager_repository import VersionManagerRepository
+
+
+class TutorVersionInstaller:
+    def __init__(self, repository: VersionManagerRepository) -> None:
+        self.repository = repository
+
+    def __call__(self, version: str) -> None:
+        version = TutorVersion(version)
+        self.repository.install_version(version=version)

--- a/tvm/version_manager/application/tutor_version_uninstaller.py
+++ b/tvm/version_manager/application/tutor_version_uninstaller.py
@@ -1,0 +1,11 @@
+from tvm.version_manager.domain.tutor_version import TutorVersion
+from tvm.version_manager.domain.version_manager_repository import VersionManagerRepository
+
+
+class TutorVersionUninstaller:
+    def __init__(self, repository: VersionManagerRepository) -> None:
+        self.repository = repository
+
+    def __call__(self, version: str) -> None:
+        version = TutorVersion(version)
+        self.repository.uninstall_version(version)

--- a/tvm/version_manager/application/tutor_version_uninstaller.py
+++ b/tvm/version_manager/application/tutor_version_uninstaller.py
@@ -1,11 +1,16 @@
+"""Tutor version uninstaller application."""
 from tvm.version_manager.domain.tutor_version import TutorVersion
 from tvm.version_manager.domain.version_manager_repository import VersionManagerRepository
 
 
 class TutorVersionUninstaller:
+    """Tutor version uninstaller for version manager."""
+
     def __init__(self, repository: VersionManagerRepository) -> None:
+        """init."""
         self.repository = repository
 
     def __call__(self, version: str) -> None:
+        """call."""
         version = TutorVersion(version)
         self.repository.uninstall_version(version)

--- a/tvm/version_manager/application/tutor_vesion_lister.py
+++ b/tvm/version_manager/application/tutor_vesion_lister.py
@@ -1,0 +1,13 @@
+from typing import List
+from tvm.version_manager.domain.tutor_version import TutorVersion
+from tvm.version_manager.domain.version_manager_repository import (
+    VersionManagerRepository,
+)
+
+
+class TutorVersionLister:
+    def __init__(self, repository: VersionManagerRepository) -> None:
+        self.repository = repository
+
+    def __call__(self) -> List[TutorVersion]:
+        return self.repository.list_versions()

--- a/tvm/version_manager/application/tutor_vesion_lister.py
+++ b/tvm/version_manager/application/tutor_vesion_lister.py
@@ -9,5 +9,5 @@ class TutorVersionLister:
     def __init__(self, repository: VersionManagerRepository) -> None:
         self.repository = repository
 
-    def __call__(self) -> List[TutorVersion]:
-        return self.repository.list_versions()
+    def __call__(self, limit: int) -> List[TutorVersion]:
+        return self.repository.list_versions(limit=limit)

--- a/tvm/version_manager/application/tutor_vesion_lister.py
+++ b/tvm/version_manager/application/tutor_vesion_lister.py
@@ -1,13 +1,17 @@
+"""Tutor version application."""
 from typing import List
+
 from tvm.version_manager.domain.tutor_version import TutorVersion
-from tvm.version_manager.domain.version_manager_repository import (
-    VersionManagerRepository,
-)
+from tvm.version_manager.domain.version_manager_repository import VersionManagerRepository
 
 
 class TutorVersionLister:
+    """Tutor version lister for version manage."""
+
     def __init__(self, repository: VersionManagerRepository) -> None:
+        """init."""
         self.repository = repository
 
     def __call__(self, limit: int) -> List[TutorVersion]:
+        """call."""
         return self.repository.list_versions(limit=limit)

--- a/tvm/version_manager/domain/__init__.py
+++ b/tvm/version_manager/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Domain init."""

--- a/tvm/version_manager/domain/tutor_version.py
+++ b/tvm/version_manager/domain/tutor_version.py
@@ -13,4 +13,3 @@ class TutorVersion(str):
         result = re.match(r'^v([0-9]+)\.([0-9]+)\.([0-9]+)$', value)
         if not result:
             raise TutorVersionFormatError("format must be 'vX.Y.Z'")
-

--- a/tvm/version_manager/domain/tutor_version.py
+++ b/tvm/version_manager/domain/tutor_version.py
@@ -1,0 +1,14 @@
+import re
+
+from tvm.version_manager.domain.tutor_version_format_error import (
+    TutorVersionFormatError,
+)
+
+
+class TutorVersion(str):
+    def __init__(self, value):
+        """Raise BadParameter if the value is not a tutor version."""
+
+        result = re.match(r"^v([0-9]+)\.([0-9]+)\.([0-9]+)$", value)
+        if not result:
+            raise TutorVersionFormatError("format must be 'vX.Y.Z'")

--- a/tvm/version_manager/domain/tutor_version.py
+++ b/tvm/version_manager/domain/tutor_version.py
@@ -1,14 +1,16 @@
 import re
-
 from tvm.version_manager.domain.tutor_version_format_error import (
     TutorVersionFormatError,
 )
 
 
 class TutorVersion(str):
-    def __init__(self, value):
+    def __init__(self, value: str, file_url: str = None):
         """Raise BadParameter if the value is not a tutor version."""
+        self._value = value
+        self._file_url = file_url
 
-        result = re.match(r"^v([0-9]+)\.([0-9]+)\.([0-9]+)$", value)
+        result = re.match(r'^v([0-9]+)\.([0-9]+)\.([0-9]+)$', value)
         if not result:
             raise TutorVersionFormatError("format must be 'vX.Y.Z'")
+

--- a/tvm/version_manager/domain/tutor_version.py
+++ b/tvm/version_manager/domain/tutor_version.py
@@ -1,15 +1,17 @@
+"""Tutor version domain."""
 import re
-from tvm.version_manager.domain.tutor_version_format_error import (
-    TutorVersionFormatError,
-)
+
+from tvm.version_manager.domain.tutor_version_format_error import TutorVersionFormatError
 
 
 class TutorVersion(str):
-    def __init__(self, value: str, file_url: str = None):
+    """Tutor version format."""
+
+    def __init__(self, value: str, file_url: str = None):  # pylint: disable=super-init-not-called
         """Raise BadParameter if the value is not a tutor version."""
         self._value = value
         self._file_url = file_url
 
-        result = re.match(r'^v([0-9]+)\.([0-9]+)\.([0-9]+)$', value)
+        result = re.match(r"^v([0-9]+)\.([0-9]+)\.([0-9]+)$", value)
         if not result:
             raise TutorVersionFormatError("format must be 'vX.Y.Z'")

--- a/tvm/version_manager/domain/tutor_version_format_error.py
+++ b/tvm/version_manager/domain/tutor_version_format_error.py
@@ -1,0 +1,2 @@
+class TutorVersionFormatError(Exception):
+    pass

--- a/tvm/version_manager/domain/tutor_version_format_error.py
+++ b/tvm/version_manager/domain/tutor_version_format_error.py
@@ -1,2 +1,5 @@
+"""Tutor version format error message."""
+
+
 class TutorVersionFormatError(Exception):
-    pass
+    """Tutor version format error exception."""

--- a/tvm/version_manager/domain/tutor_version_is_not_installed.py
+++ b/tvm/version_manager/domain/tutor_version_is_not_installed.py
@@ -1,0 +1,2 @@
+class TutorVersionIsNotInstalled(Exception):
+    pass

--- a/tvm/version_manager/domain/tutor_version_is_not_installed.py
+++ b/tvm/version_manager/domain/tutor_version_is_not_installed.py
@@ -1,2 +1,5 @@
+"""Tutor vesion is not installed."""
+
+
 class TutorVersionIsNotInstalled(Exception):
-    pass
+    """Tutor vesion is not installed  domain."""

--- a/tvm/version_manager/domain/version_manager_repository.py
+++ b/tvm/version_manager/domain/version_manager_repository.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Optional
 
 from tvm.version_manager.domain.tutor_version import TutorVersion
 
@@ -17,4 +17,12 @@ class VersionManagerRepository(ABC):
     @staticmethod
     @abstractmethod
     def current_version(tvm_path: str) -> List[TutorVersion]:
+        pass
+
+    @abstractmethod
+    def install_version(self, version: TutorVersion) -> None:
+        pass
+
+    @abstractmethod
+    def find_version(self, version: TutorVersion) -> Optional[TutorVersion]:
         pass

--- a/tvm/version_manager/domain/version_manager_repository.py
+++ b/tvm/version_manager/domain/version_manager_repository.py
@@ -30,3 +30,12 @@ class VersionManagerRepository(ABC):
     @abstractmethod
     def uninstall_version(self, version: TutorVersion) -> None:
         pass
+
+    @abstractmethod
+    def use_version(self, version: TutorVersion) -> None:
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def version_is_installed(version: str) -> None:
+        pass

--- a/tvm/version_manager/domain/version_manager_repository.py
+++ b/tvm/version_manager/domain/version_manager_repository.py
@@ -1,0 +1,10 @@
+from abc import ABC, abstractmethod
+from typing import List
+
+from tvm.version_manager.domain.tutor_version import TutorVersion
+
+
+class VersionManagerRepository(ABC):
+    @abstractmethod
+    def list_versions(self) -> List[TutorVersion]:
+        pass

--- a/tvm/version_manager/domain/version_manager_repository.py
+++ b/tvm/version_manager/domain/version_manager_repository.py
@@ -1,3 +1,4 @@
+"""Version manager repository methods."""
 from abc import ABC, abstractmethod
 from typing import List, Optional
 
@@ -5,45 +6,47 @@ from tvm.version_manager.domain.tutor_version import TutorVersion
 
 
 class VersionManagerRepository(ABC):
+    """Administrate version manager repository methods."""
+
     @abstractmethod
     def list_versions(self, limit: int) -> List[TutorVersion]:
-        pass
+        """List versions of the version manager."""
 
     @staticmethod
     @abstractmethod
     def local_versions(tvm_path: str) -> List[TutorVersion]:
-        pass
+        """List local versions of the version manager."""
 
     @staticmethod
     @abstractmethod
     def current_version(tvm_path: str) -> List[TutorVersion]:
-        pass
+        """Present the current version of the version manager."""
 
     @abstractmethod
     def install_version(self, version: TutorVersion) -> None:
-        pass
+        """Install the version manager for tutor version."""
 
     @abstractmethod
     def find_version(self, version: TutorVersion) -> Optional[TutorVersion]:
-        pass
+        """Find the tutor version manager."""
 
     @abstractmethod
     def uninstall_version(self, version: TutorVersion) -> None:
-        pass
+        """Uninstall the version manager for tutor version selected."""
 
     @abstractmethod
     def use_version(self, version: TutorVersion) -> None:
-        pass
+        """Use selected version when is installed."""
 
     @staticmethod
     @abstractmethod
     def version_is_installed(version: str) -> None:
-        pass
+        """Version is installed method."""
 
     @abstractmethod
     def install_plugin(self, options: List) -> None:
-        pass
+        """Install tutor plugin."""
 
     @abstractmethod
     def uninstall_plugin(self, options: List) -> None:
-        pass
+        """Uninstall tutor plugin."""

--- a/tvm/version_manager/domain/version_manager_repository.py
+++ b/tvm/version_manager/domain/version_manager_repository.py
@@ -39,3 +39,11 @@ class VersionManagerRepository(ABC):
     @abstractmethod
     def version_is_installed(version: str) -> None:
         pass
+
+    @abstractmethod
+    def install_plugin(self, options: List) -> None:
+        pass
+
+    @abstractmethod
+    def uninstall_plugin(self, options: List) -> None:
+        pass

--- a/tvm/version_manager/domain/version_manager_repository.py
+++ b/tvm/version_manager/domain/version_manager_repository.py
@@ -8,3 +8,13 @@ class VersionManagerRepository(ABC):
     @abstractmethod
     def list_versions(self) -> List[TutorVersion]:
         pass
+
+    @staticmethod
+    @abstractmethod
+    def local_versions(tvm_path: str) -> List[TutorVersion]:
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def current_version(tvm_path: str) -> List[TutorVersion]:
+        pass

--- a/tvm/version_manager/domain/version_manager_repository.py
+++ b/tvm/version_manager/domain/version_manager_repository.py
@@ -6,7 +6,7 @@ from tvm.version_manager.domain.tutor_version import TutorVersion
 
 class VersionManagerRepository(ABC):
     @abstractmethod
-    def list_versions(self) -> List[TutorVersion]:
+    def list_versions(self, limit: int) -> List[TutorVersion]:
         pass
 
     @staticmethod

--- a/tvm/version_manager/domain/version_manager_repository.py
+++ b/tvm/version_manager/domain/version_manager_repository.py
@@ -26,3 +26,7 @@ class VersionManagerRepository(ABC):
     @abstractmethod
     def find_version(self, version: TutorVersion) -> Optional[TutorVersion]:
         pass
+
+    @abstractmethod
+    def uninstall_version(self, version: TutorVersion) -> None:
+        pass

--- a/tvm/version_manager/infrastructure/__init__.py
+++ b/tvm/version_manager/infrastructure/__init__.py
@@ -1,0 +1,1 @@
+"""Infrastructure init."""

--- a/tvm/version_manager/infrastructure/version_manager_git_repository.py
+++ b/tvm/version_manager/infrastructure/version_manager_git_repository.py
@@ -5,9 +5,11 @@ import shutil
 import stat
 import pathlib
 import subprocess
+import sys
 import zipfile
 from typing import List, Optional
 
+import click
 import requests
 from tvm.version_manager.domain.tutor_version import TutorVersion
 from tvm.version_manager.domain.tutor_version_is_not_installed import TutorVersionIsNotInstalled
@@ -147,6 +149,21 @@ class VersionManagerGitRepository(VersionManagerRepository):
         subprocess.run(f'cd {self.TVM_PATH}/{version}; virtualenv --prompt {version} venv',
                        shell=True, check=True,
                        executable='/bin/bash')
+
+    def run_command_in_virtualenv(self, options: List):
+        try:
+            subprocess.run(f'source {self.TVM_PATH}/venv/bin/activate;'
+                       f'pip {" ".join(options)}',
+                       shell=True, check=True,
+                       executable='/bin/bash')
+        except subprocess.CalledProcessError as ex:
+            raise Exception(f'Error running venv commands: {ex.output}')
+
+    def install_plugin(self, options: List) -> None:
+        self.run_command_in_virtualenv(options)
+
+    def uninstall_plugin(self, options: List) -> None:
+        self.run_command_in_virtualenv(options)
 
     def install_tutor(self, version: TutorVersion) -> None:
         subprocess.run(f'source {self.TVM_PATH}/{version}/venv/bin/activate;'

--- a/tvm/version_manager/infrastructure/version_manager_git_repository.py
+++ b/tvm/version_manager/infrastructure/version_manager_git_repository.py
@@ -1,6 +1,10 @@
-"Actions to get tutor versions"
+"""Actions to get tutor versions"""
 import json
 import os
+import stat
+import pathlib
+import subprocess
+import zipfile
 from typing import List, Optional
 
 import requests
@@ -8,12 +12,76 @@ from tvm.version_manager.domain.tutor_version import TutorVersion
 from tvm.version_manager.domain.version_manager_repository import (
     VersionManagerRepository,
 )
+from tvm.version_manager.templates.tutor_switcher import TUTOR_SWITCHER_TEMPLATE
 
 
 class VersionManagerGitRepository(VersionManagerRepository):
-    "Principals commands to manage TVM"
+    """Principals commands to manage TVM"""
 
     VERSIONS_URL = "https://api.github.com/repos/overhangio/tutor/tags"
+    GET_TAG_URL = "https://api.github.com/repos/overhangio/tutor/git/ref/tags/"
+    ZIPPBALL_URL = "https://api.github.com/repos/overhangio/tutor/zipball/refs/tags/"
+    TVM_PATH = pathlib.Path.home() / ".tvm"
+
+    def __init__(self) -> None:
+        self.setup()
+
+    def setup(self):
+        try:
+            os.mkdir(self.TVM_PATH)
+        except FileExistsError:
+            pass
+
+        data = {
+            "version": None,
+            "tutor_root": None,
+            "tutor_plugins_root": None,
+        }
+
+        self.set_current_info(data=data, update=False)
+        self.set_switcher()
+
+        try:
+            os.symlink(f'{self.TVM_PATH}/tutor_switcher', '/usr/local/bin/tutor')
+        except PermissionError:
+            subprocess.call(['sudo', 'ln', '-s', f'{self.TVM_PATH}/tutor_switcher', '/usr/local/bin/tutor'])
+        except FileExistsError:
+            pass
+
+    def set_current_info(self, data: dict, update: bool = True) -> None:
+        try:
+            info_file_path = f'{self.TVM_PATH}/current_bin.json'
+            if os.path.exists(info_file_path) and not update:
+                raise FileExistsError
+
+            with open(info_file_path, 'w', encoding='utf-8') as info_file:
+                json.dump(data, info_file, indent=4)
+        except FileExistsError:
+            pass
+
+    def get_current_info(self) -> dict:
+        info_file_path = f'{self.TVM_PATH}/current_bin.json'
+        with open(info_file_path, 'r', encoding='utf-8') as info_file:
+            data = json.load(info_file)
+        return data
+
+    def set_switcher(self) -> None:
+        """Set the active version from the json into the switcher."""
+        data = self.get_current_info()
+
+        context = {
+            'version': data.get('version', None),
+            'tutor_root': data.get('tutor_root', None),
+            'tutor_plugins_root': data.get('tutor_plugins_root', None),
+            'tvm': f"{self.TVM_PATH}",
+        }
+
+        switcher_file = f'{self.TVM_PATH}/tutor_switcher'
+        with open(switcher_file, mode='w', encoding='utf-8') as of_text:
+            of_text.write(TUTOR_SWITCHER_TEMPLATE.render(**context))
+
+        # set execute permissions
+        os.chmod(switcher_file, stat.S_IRWXU | stat.S_IRWXG | stat.S_IROTH | stat.S_IXOTH)
 
     def get_version_from_api(self, limit: int = 10):
         "Return api information form request"
@@ -45,5 +113,41 @@ class VersionManagerGitRepository(VersionManagerRepository):
 
         with open(info_file_path, "r", encoding="utf-8") as info_file:
             data = json.load(info_file)
-
         return TutorVersion(data.get("version")) if data.get("version") else None
+
+    def install_version(self, version: TutorVersion) -> None:
+        # Get the code in zip format
+        filename = f'{self.TVM_PATH}/{version}.zip'
+        file_url = f"{self.ZIPPBALL_URL}{version}"
+        stream = requests.get(file_url, stream=True)
+        with open(filename, 'wb') as target_file:
+            for chunk in stream.iter_content(chunk_size=256):
+                target_file.write(chunk)
+
+        # Unzip it
+        with zipfile.ZipFile(filename, "r") as ziped:
+            ziped.extractall(f'{self.TVM_PATH}/{version}')
+
+        # Delete artifact
+        os.remove(filename)
+
+        self.create_virtualenv(version)
+        self.install_tutor(version)
+
+    def find_version(self, version: TutorVersion) -> Optional[TutorVersion]:
+        response = requests.get(f"{self.GET_TAG_URL}{version}")
+        if response.status_code == 404:
+            return None
+
+        return TutorVersion(version)
+
+    def create_virtualenv(self, version: TutorVersion) -> None:
+        subprocess.run(f'cd {self.TVM_PATH}/{version}; virtualenv --prompt {version} venv',
+                       shell=True, check=True,
+                       executable='/bin/bash')
+
+    def install_tutor(self, version: TutorVersion) -> None:
+        subprocess.run(f'source {self.TVM_PATH}/{version}/venv/bin/activate;'
+                       f'pip install -e {self.TVM_PATH}/{version}/overhangio-tutor-*/',
+                       shell=True, check=True,
+                       executable='/bin/bash')

--- a/tvm/version_manager/infrastructure/version_manager_git_repository.py
+++ b/tvm/version_manager/infrastructure/version_manager_git_repository.py
@@ -1,7 +1,7 @@
+"Actions to get tutor versions"
 import json
 import os
-import pathlib
-from typing import List
+from typing import List, Optional
 
 import requests
 from tvm.version_manager.domain.tutor_version import TutorVersion
@@ -11,10 +11,13 @@ from tvm.version_manager.domain.version_manager_repository import (
 
 
 class VersionManagerGitRepository(VersionManagerRepository):
+    "Principals commands to manage TVM"
+
     VERSIONS_URL = "https://api.github.com/repos/overhangio/tutor/tags"
-    TVM_PATH = pathlib.Path.home() / ".tvm"
 
     def get_version_from_api(self, limit: int = 10):
+        "Return api information form request"
+
         api_info = requests.get(f"{self.VERSIONS_URL}?per_page={limit}").json()
         return api_info
 
@@ -22,28 +25,25 @@ class VersionManagerGitRepository(VersionManagerRepository):
         api_info = self.get_version_from_api()
         return [TutorVersion(x.get("name")) for x in api_info]
 
-    def get_tutor_local_versions(self):
+    @staticmethod
+    def local_versions(tvm_path: str) -> List[TutorVersion]:
         """Return a list of strings with the local version installed. If None, returns empty array."""
-        if os.path.exists(f"{self.TVM_PATH}"):
+
+        if os.path.exists(f"{tvm_path}"):
             return [
-                x
-                for x in os.listdir(f"{self.TVM_PATH}")
-                if os.path.isdir(f"{self.TVM_PATH}/{x}")
+                x for x in os.listdir(f"{tvm_path}") if os.path.isdir(f"{tvm_path}/{x}")
             ]
         return []
 
-    def get_active_tutor_version(self) -> str:
+    @staticmethod
+    def current_version(tvm_path: str) -> Optional[TutorVersion]:
         """Read the current active version from the json/bash switcher."""
-        info_file_path = f"{self.TVM_PATH}/current_bin.json"
-        if os.path.exists(info_file_path):
-            with open(info_file_path, "r", encoding="utf-8") as info_file:
-                data = json.load(info_file)
-            return data.get("version", "Invalid active version")
-        return "No active version installed"
 
-    def get_project_tutor_version(self, tvm_project_path) -> str:
-        """Read the current active version from the json/bash switcher."""
-        info_file_path = f"{tvm_project_path}/config.json"
+        info_file_path = f"{tvm_path}/current_bin.json"
+        if not os.path.exists(info_file_path):
+            return None
+
         with open(info_file_path, "r", encoding="utf-8") as info_file:
             data = json.load(info_file)
-        return data.get("version")
+
+        return TutorVersion(data.get("version")) if data.get("version") else None

--- a/tvm/version_manager/infrastructure/version_manager_git_repository.py
+++ b/tvm/version_manager/infrastructure/version_manager_git_repository.py
@@ -1,6 +1,7 @@
 """Actions to get tutor versions"""
 import json
 import os
+import shutil
 import stat
 import pathlib
 import subprocess
@@ -9,6 +10,7 @@ from typing import List, Optional
 
 import requests
 from tvm.version_manager.domain.tutor_version import TutorVersion
+from tvm.version_manager.domain.tutor_version_is_not_installed import TutorVersionIsNotInstalled
 from tvm.version_manager.domain.version_manager_repository import (
     VersionManagerRepository,
 )
@@ -151,3 +153,9 @@ class VersionManagerGitRepository(VersionManagerRepository):
                        f'pip install -e {self.TVM_PATH}/{version}/overhangio-tutor-*/',
                        shell=True, check=True,
                        executable='/bin/bash')
+
+    def uninstall_version(self, version: TutorVersion) -> None:
+        try:
+            shutil.rmtree(f'{self.TVM_PATH}/{version}')
+        except FileNotFoundError:
+            raise TutorVersionIsNotInstalled(f"The version {version} is not installed")

--- a/tvm/version_manager/infrastructure/version_manager_git_repository.py
+++ b/tvm/version_manager/infrastructure/version_manager_git_repository.py
@@ -159,3 +159,20 @@ class VersionManagerGitRepository(VersionManagerRepository):
             shutil.rmtree(f'{self.TVM_PATH}/{version}')
         except FileNotFoundError:
             raise TutorVersionIsNotInstalled(f"The version {version} is not installed")
+
+    def use_version(self, version: TutorVersion) -> None:
+        data = self.get_current_info()
+
+        data.update({
+            "version": version
+        })
+
+        self.set_current_info(data=data)
+        self.set_switcher()
+
+    @staticmethod
+    def version_is_installed(version: str) -> bool:
+        version = TutorVersion(version)
+        if not os.path.exists(f"{VersionManagerGitRepository.TVM_PATH}/{version}"):
+            return False
+        return True

--- a/tvm/version_manager/infrastructure/version_manager_git_repository.py
+++ b/tvm/version_manager/infrastructure/version_manager_git_repository.py
@@ -86,13 +86,13 @@ class VersionManagerGitRepository(VersionManagerRepository):
         os.chmod(switcher_file, stat.S_IRWXU | stat.S_IRWXG | stat.S_IROTH | stat.S_IXOTH)
 
     def get_version_from_api(self, limit: int = 10):
-        "Return api information form request"
+        """Return api information form request"""
 
         api_info = requests.get(f"{self.VERSIONS_URL}?per_page={limit}").json()
         return api_info
 
-    def list_versions(self) -> List[TutorVersion]:
-        api_info = self.get_version_from_api()
+    def list_versions(self, limit: int) -> List[TutorVersion]:
+        api_info = self.get_version_from_api(limit=limit)
         return [TutorVersion(x.get("name")) for x in api_info]
 
     @staticmethod

--- a/tvm/version_manager/infrastructure/version_manager_git_repository.py
+++ b/tvm/version_manager/infrastructure/version_manager_git_repository.py
@@ -1,0 +1,49 @@
+import json
+import os
+import pathlib
+from typing import List
+
+import requests
+from tvm.version_manager.domain.tutor_version import TutorVersion
+from tvm.version_manager.domain.version_manager_repository import (
+    VersionManagerRepository,
+)
+
+
+class VersionManagerGitRepository(VersionManagerRepository):
+    VERSIONS_URL = "https://api.github.com/repos/overhangio/tutor/tags"
+    TVM_PATH = pathlib.Path.home() / ".tvm"
+
+    def get_version_from_api(self, limit: int = 10):
+        api_info = requests.get(f"{self.VERSIONS_URL}?per_page={limit}").json()
+        return api_info
+
+    def list_versions(self) -> List[TutorVersion]:
+        api_info = self.get_version_from_api()
+        return [TutorVersion(x.get("name")) for x in api_info]
+
+    def get_tutor_local_versions(self):
+        """Return a list of strings with the local version installed. If None, returns empty array."""
+        if os.path.exists(f"{self.TVM_PATH}"):
+            return [
+                x
+                for x in os.listdir(f"{self.TVM_PATH}")
+                if os.path.isdir(f"{self.TVM_PATH}/{x}")
+            ]
+        return []
+
+    def get_active_tutor_version(self) -> str:
+        """Read the current active version from the json/bash switcher."""
+        info_file_path = f"{self.TVM_PATH}/current_bin.json"
+        if os.path.exists(info_file_path):
+            with open(info_file_path, "r", encoding="utf-8") as info_file:
+                data = json.load(info_file)
+            return data.get("version", "Invalid active version")
+        return "No active version installed"
+
+    def get_project_tutor_version(self, tvm_project_path) -> str:
+        """Read the current active version from the json/bash switcher."""
+        info_file_path = f"{tvm_project_path}/config.json"
+        with open(info_file_path, "r", encoding="utf-8") as info_file:
+            data = json.load(info_file)
+        return data.get("version")

--- a/tvm/version_manager/infrastructure/version_manager_git_repository.py
+++ b/tvm/version_manager/infrastructure/version_manager_git_repository.py
@@ -1,26 +1,23 @@
-"""Actions to get tutor versions"""
+"""Actions to get tutor versions."""
 import json
 import os
+import pathlib
 import shutil
 import stat
-import pathlib
 import subprocess
-import sys
 import zipfile
 from typing import List, Optional
 
-import click
 import requests
+
 from tvm.version_manager.domain.tutor_version import TutorVersion
 from tvm.version_manager.domain.tutor_version_is_not_installed import TutorVersionIsNotInstalled
-from tvm.version_manager.domain.version_manager_repository import (
-    VersionManagerRepository,
-)
+from tvm.version_manager.domain.version_manager_repository import VersionManagerRepository
 from tvm.version_manager.templates.tutor_switcher import TUTOR_SWITCHER_TEMPLATE
 
 
 class VersionManagerGitRepository(VersionManagerRepository):
-    """Principals commands to manage TVM"""
+    """Principals commands to manage TVM."""
 
     VERSIONS_URL = "https://api.github.com/repos/overhangio/tutor/tags"
     GET_TAG_URL = "https://api.github.com/repos/overhangio/tutor/git/ref/tags/"
@@ -28,9 +25,11 @@ class VersionManagerGitRepository(VersionManagerRepository):
     TVM_PATH = pathlib.Path.home() / ".tvm"
 
     def __init__(self) -> None:
+        """init."""
         self.setup()
 
     def setup(self):
+        """Set data."""
         try:
             os.mkdir(self.TVM_PATH)
         except FileExistsError:
@@ -46,26 +45,36 @@ class VersionManagerGitRepository(VersionManagerRepository):
         self.set_switcher()
 
         try:
-            os.symlink(f'{self.TVM_PATH}/tutor_switcher', '/usr/local/bin/tutor')
+            os.symlink(f"{self.TVM_PATH}/tutor_switcher", "/usr/local/bin/tutor")
         except PermissionError:
-            subprocess.call(['sudo', 'ln', '-s', f'{self.TVM_PATH}/tutor_switcher', '/usr/local/bin/tutor'])
+            subprocess.call(
+                [
+                    "sudo",
+                    "ln",
+                    "-s",
+                    f"{self.TVM_PATH}/tutor_switcher",
+                    "/usr/local/bin/tutor",
+                ]
+            )
         except FileExistsError:
             pass
 
     def set_current_info(self, data: dict, update: bool = True) -> None:
+        """Set current information."""
         try:
-            info_file_path = f'{self.TVM_PATH}/current_bin.json'
+            info_file_path = f"{self.TVM_PATH}/current_bin.json"
             if os.path.exists(info_file_path) and not update:
                 raise FileExistsError
 
-            with open(info_file_path, 'w', encoding='utf-8') as info_file:
+            with open(info_file_path, "w", encoding="utf-8") as info_file:
                 json.dump(data, info_file, indent=4)
         except FileExistsError:
             pass
 
     def get_current_info(self) -> dict:
-        info_file_path = f'{self.TVM_PATH}/current_bin.json'
-        with open(info_file_path, 'r', encoding='utf-8') as info_file:
+        """Get current information data from the json."""
+        info_file_path = f"{self.TVM_PATH}/current_bin.json"
+        with open(info_file_path, "r", encoding="utf-8") as info_file:
             data = json.load(info_file)
         return data
 
@@ -74,33 +83,34 @@ class VersionManagerGitRepository(VersionManagerRepository):
         data = self.get_current_info()
 
         context = {
-            'version': data.get('version', None),
-            'tutor_root': data.get('tutor_root', None),
-            'tutor_plugins_root': data.get('tutor_plugins_root', None),
-            'tvm': f"{self.TVM_PATH}",
+            "version": data.get("version", None),
+            "tutor_root": data.get("tutor_root", None),
+            "tutor_plugins_root": data.get("tutor_plugins_root", None),
+            "tvm": f"{self.TVM_PATH}",
         }
 
-        switcher_file = f'{self.TVM_PATH}/tutor_switcher'
-        with open(switcher_file, mode='w', encoding='utf-8') as of_text:
+        switcher_file = f"{self.TVM_PATH}/tutor_switcher"
+        with open(switcher_file, mode="w", encoding="utf-8") as of_text:
             of_text.write(TUTOR_SWITCHER_TEMPLATE.render(**context))
 
         # set execute permissions
-        os.chmod(switcher_file, stat.S_IRWXU | stat.S_IRWXG | stat.S_IROTH | stat.S_IXOTH)
+        os.chmod(
+            switcher_file, stat.S_IRWXU | stat.S_IRWXG | stat.S_IROTH | stat.S_IXOTH
+        )
 
     def get_version_from_api(self, limit: int = 10):
-        """Return api information form request"""
-
+        """Return api information form request."""
         api_info = requests.get(f"{self.VERSIONS_URL}?per_page={limit}").json()
         return api_info
 
     def list_versions(self, limit: int) -> List[TutorVersion]:
+        """List tutor version from API."""
         api_info = self.get_version_from_api(limit=limit)
         return [TutorVersion(x.get("name")) for x in api_info]
 
     @staticmethod
     def local_versions(tvm_path: str) -> List[TutorVersion]:
         """Return a list of strings with the local version installed. If None, returns empty array."""
-
         if os.path.exists(f"{tvm_path}"):
             return [
                 x for x in os.listdir(f"{tvm_path}") if os.path.isdir(f"{tvm_path}/{x}")
@@ -110,7 +120,6 @@ class VersionManagerGitRepository(VersionManagerRepository):
     @staticmethod
     def current_version(tvm_path: str) -> Optional[TutorVersion]:
         """Read the current active version from the json/bash switcher."""
-
         info_file_path = f"{tvm_path}/current_bin.json"
         if not os.path.exists(info_file_path):
             return None
@@ -120,17 +129,18 @@ class VersionManagerGitRepository(VersionManagerRepository):
         return TutorVersion(data.get("version")) if data.get("version") else None
 
     def install_version(self, version: TutorVersion) -> None:
+        """Install version for a tutor version."""
         # Get the code in zip format
-        filename = f'{self.TVM_PATH}/{version}.zip'
+        filename = f"{self.TVM_PATH}/{version}.zip"
         file_url = f"{self.ZIPPBALL_URL}{version}"
         stream = requests.get(file_url, stream=True)
-        with open(filename, 'wb') as target_file:
+        with open(filename, "wb") as target_file:
             for chunk in stream.iter_content(chunk_size=256):
                 target_file.write(chunk)
 
         # Unzip it
         with zipfile.ZipFile(filename, "r") as ziped:
-            ziped.extractall(f'{self.TVM_PATH}/{version}')
+            ziped.extractall(f"{self.TVM_PATH}/{version}")
 
         # Delete artifact
         os.remove(filename)
@@ -139,6 +149,7 @@ class VersionManagerGitRepository(VersionManagerRepository):
         self.install_tutor(version)
 
     def find_version(self, version: TutorVersion) -> Optional[TutorVersion]:
+        """Find version for requests."""
         response = requests.get(f"{self.GET_TAG_URL}{version}")
         if response.status_code == 404:
             return None
@@ -146,49 +157,65 @@ class VersionManagerGitRepository(VersionManagerRepository):
         return TutorVersion(version)
 
     def create_virtualenv(self, version: TutorVersion) -> None:
-        subprocess.run(f'cd {self.TVM_PATH}/{version}; virtualenv --prompt {version} venv',
-                       shell=True, check=True,
-                       executable='/bin/bash')
+        """Create a virtual environment."""
+        subprocess.run(
+            f"cd {self.TVM_PATH}/{version}; virtualenv --prompt {version} venv",
+            shell=True,
+            check=True,
+            executable="/bin/bash",
+        )
 
     def run_command_in_virtualenv(self, options: List):
+        """Use virtual environment to run command."""
         try:
-            subprocess.run(f'source {self.TVM_PATH}/venv/bin/activate;'
-                       f'pip {" ".join(options)}',
-                       shell=True, check=True,
-                       executable='/bin/bash')
+            subprocess.run(
+                f"source {self.TVM_PATH}/venv/bin/activate;" f'pip {" ".join(options)}',
+                shell=True,
+                check=True,
+                executable="/bin/bash",
+            )
         except subprocess.CalledProcessError as ex:
-            raise Exception(f'Error running venv commands: {ex.output}')
+            raise Exception(f"Error running venv commands: {ex.output}") from ex
 
     def install_plugin(self, options: List) -> None:
+        """Install plugin for virtual environment."""
         self.run_command_in_virtualenv(options)
 
     def uninstall_plugin(self, options: List) -> None:
+        """Uninstall plugin for virtual environment."""
         self.run_command_in_virtualenv(options)
 
     def install_tutor(self, version: TutorVersion) -> None:
-        subprocess.run(f'source {self.TVM_PATH}/{version}/venv/bin/activate;'
-                       f'pip install -e {self.TVM_PATH}/{version}/overhangio-tutor-*/',
-                       shell=True, check=True,
-                       executable='/bin/bash')
+        """Install a tutor version."""
+        subprocess.run(
+            f"source {self.TVM_PATH}/{version}/venv/bin/activate;"
+            f"pip install -e {self.TVM_PATH}/{version}/overhangio-tutor-*/",
+            shell=True,
+            check=True,
+            executable="/bin/bash",
+        )
 
     def uninstall_version(self, version: TutorVersion) -> None:
+        """Uninstall a tutor version."""
         try:
-            shutil.rmtree(f'{self.TVM_PATH}/{version}')
-        except FileNotFoundError:
-            raise TutorVersionIsNotInstalled(f"The version {version} is not installed")
+            shutil.rmtree(f"{self.TVM_PATH}/{version}")
+        except FileNotFoundError as v_not_exist:
+            raise TutorVersionIsNotInstalled(
+                f"The version {version} is not installed"
+            ) from v_not_exist
 
     def use_version(self, version: TutorVersion) -> None:
+        """Use a tutor version selected."""
         data = self.get_current_info()
 
-        data.update({
-            "version": version
-        })
+        data.update({"version": version})
 
         self.set_current_info(data=data)
         self.set_switcher()
 
     @staticmethod
     def version_is_installed(version: str) -> bool:
+        """Validate if tutor version is installed."""
         version = TutorVersion(version)
         if not os.path.exists(f"{VersionManagerGitRepository.TVM_PATH}/{version}"):
             return False

--- a/tvm/version_manager/templates/__init__.py
+++ b/tvm/version_manager/templates/__init__.py
@@ -1,0 +1,1 @@
+"""Template init."""

--- a/tvm/version_manager/templates/tutor_switcher.py
+++ b/tvm/version_manager/templates/tutor_switcher.py
@@ -1,0 +1,16 @@
+"""Tutor switcher jinja template."""
+from jinja2 import Template
+
+TEMPLATE = '''
+{% if tutor_root %}
+export TUTOR_ROOT={{ tutor_root }}
+export TUTOR_PLUGINS_ROOT={{ tutor_plugins_root }}
+{% endif %}
+{% if version %}
+{{ tvm }}/{{ version }}/venv/bin/tutor $@
+{% else %}
+echo "You need to select a tutor active version at first. Run 'tvm use <VERSION>'"
+{% endif %}
+'''
+
+TUTOR_SWITCHER_TEMPLATE = Template(TEMPLATE)


### PR DESCRIPTION
Description
========
This PR migrates some commands to clean architecture (hexagon architecture), the commands are:
- list_versions
- install
- uninstall
- use
- install_plugin
- uninstall_plugin

The unit test was made only for commands above

How to test:
=========
1. Use this branch (perf/tvm_migrate_commands)
2. Create and activate a virtual environment
3. Run commands of the description, Examples:
```bash
tvm list
tvm install v13.3.1
tvm uninstall v13.3.1
tvm use v13.3.1
tvm plugins install tutor-mfe
tvm plugins uninstall tutor-mfe
```
5. Run ``make run_tests`` to verify the unit tests.

## Checklist for Merge

- [x] Tested in a local environment
- [x] Updated documentation
- [ ] At less an approval
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->