### PR TITLE
fix: add virtualenv to requirements and upgrade

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,3 +6,4 @@ requests
 jinja2
 pyyaml
 GitPython
+virtualenv

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,10 +6,14 @@
 #
 certifi==2022.6.15
     # via requests
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via requests
 click==8.1.3
     # via -r requirements/base.in
+distlib==0.3.5
+    # via virtualenv
+filelock==3.8.0
+    # via virtualenv
 gitdb==4.0.9
     # via gitpython
 gitpython==3.1.27
@@ -20,11 +24,15 @@ jinja2==3.1.2
     # via -r requirements/base.in
 markupsafe==2.1.1
     # via jinja2
+platformdirs==2.5.2
+    # via virtualenv
 pyyaml==6.0
     # via -r requirements/base.in
 requests==2.28.1
     # via -r requirements/base.in
 smmap==5.0.0
     # via gitdb
-urllib3==1.26.11
+urllib3==1.26.12
     # via requests
+virtualenv==20.16.3
+    # via -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,16 +12,24 @@ certifi==2022.6.15
     # via
     #   -r requirements/base.txt
     #   requests
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via
     #   -r requirements/base.txt
     #   requests
 click==8.1.3
     # via -r requirements/base.txt
-coverage==6.4.2
+coverage==6.4.4
     # via -r requirements/dev.in
 dill==0.3.5.1
     # via pylint
+distlib==0.3.5
+    # via
+    #   -r requirements/base.txt
+    #   virtualenv
+filelock==3.8.0
+    # via
+    #   -r requirements/base.txt
+    #   virtualenv
 gitdb==4.0.9
     # via
     #   -r requirements/base.txt
@@ -55,18 +63,21 @@ packaging==21.3
 parso==0.8.3
     # via jedi
 platformdirs==2.5.2
-    # via pylint
+    # via
+    #   -r requirements/base.txt
+    #   pylint
+    #   virtualenv
 pluggy==1.0.0
     # via pytest
 pudb==2022.1.2
     # via -r requirements/dev.in
 py==1.11.0
     # via pytest
-pycodestyle==2.9.0
+pycodestyle==2.9.1
     # via -r requirements/dev.in
 pydocstyle==6.1.1
     # via -r requirements/dev.in
-pygments==2.12.0
+pygments==2.13.0
     # via pudb
 pylint==2.14.5
     # via -r requirements/dev.in
@@ -90,9 +101,9 @@ tomli==2.0.1
     # via
     #   pylint
     #   pytest
-tomlkit==0.11.1
+tomlkit==0.11.4
     # via pylint
-urllib3==1.26.11
+urllib3==1.26.12
     # via
     #   -r requirements/base.txt
     #   requests
@@ -102,6 +113,8 @@ urwid==2.1.2
     #   urwid-readline
 urwid-readline==0.13
     # via pudb
+virtualenv==20.16.3
+    # via -r requirements/base.txt
 wrapt==1.14.1
     # via astroid
 

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.2.1
+pip==22.2.2
     # via -r requirements/pip.in
-setuptools==63.3.0
+setuptools==65.2.0
     # via -r requirements/pip.in


### PR DESCRIPTION
### This PR is for add virtualenv to requirements and do make upgrade over all requirements. This PR also solve https://github.com/eduNEXT/tvm/issues/42 issue.

### How to test it

1. Create a clean virtualenv and make sure you dont have virtualenv installed or uninstall virtualenv and tvm from your global pip.
2. Install this branch with `` pip install git+https://github.com/eduNEXT/tvm.git@hpg/DS-205-tvm-not-installing-virtualenv `` 
3. Now you should use virtualenv and run `` tvm project init <name> <tutor-version> ``without problem.