### PR TITLE
DS-220 Tener un comando para dar start a un nuevo proyecto

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ tvm install v<tutor-version>
 2. Create a new project with tutor environment manager
 
 ```bash
-tvm project <project-name> v<tutor-version>
+tvm project init <project-name> v<tutor-version>
 ```
 
 3. Open the project folder

--- a/tvm/cli.py
+++ b/tvm/cli.py
@@ -158,6 +158,7 @@ def list_versions(limit: int):
 
 
 def install_tutor_version(version: str) -> None:
+    """Install the given VERSION of tutor in the .tvm directory."""
     finder = TutorVersionFinder(repository=version_manager)
     tutor_version = finder(version=version)
     try:
@@ -170,7 +171,7 @@ def install_tutor_version(version: str) -> None:
 
     installer = TutorVersionInstaller(repository=version_manager)
     installer(version=tutor_version)
-    
+
 
 @click.command(name="install")
 @click.argument('version', required=True)
@@ -266,6 +267,7 @@ def set_switch_from_file(file: str = None) -> None:
 
 
 def use_version(version: str) -> None:
+    """Configure the path to use VERSION."""
     enabler = TutorVersionEnabler(repository=version_manager)
     try:
         if not version_manager.version_is_installed(version=version):
@@ -276,6 +278,7 @@ def use_version(version: str) -> None:
     except Exception as exc:
         raise click.ClickException(f'The version {version} is not installed you should install it before using it.\n'
                                    f'You could run the command `tvm install {version}` to install it.') from exc
+
 
 @click.command(name="use")
 @click.argument('version', required=True)

--- a/tvm/cli.py
+++ b/tvm/cli.py
@@ -361,11 +361,18 @@ def projects() -> None:
 @click.argument('version', required=False)
 def init(name: str = None, version: str = None):
     """Configure a new tvm project in the current path."""
-    if not version:
-        version = get_active_version()
+    current_version = version_manager.current_version(f"{TVM_PATH}")
 
-    if not version_is_installed(version):
-        raise click.UsageError(f'Could not find target: {version}')
+    if not version:
+        version = current_version
+
+    if not current_version and not version:
+        lister = TutorVersionLister(repository=version_manager)
+        version = lister(limit=1)[0]
+
+    if not current_version:
+        subprocess.run(f"tvm install {version}", shell=True, check=True)
+        subprocess.run(f"tvm use {version}", shell=True, check=True)
 
     if name:
         tvm_project_folder = pathlib.Path().resolve() / name

--- a/tvm/cli.py
+++ b/tvm/cli.py
@@ -157,10 +157,7 @@ def list_versions(limit: int):
         click.echo(click.style(name, fg=color))
 
 
-@click.command(name="install")
-@click.argument('version', required=True)
-def install(version: str):
-    """Install the given VERSION of tutor in the .tvm directory."""
+def install_tutor_version(version: str) -> None:
     finder = TutorVersionFinder(repository=version_manager)
     tutor_version = finder(version=version)
     try:
@@ -173,6 +170,13 @@ def install(version: str):
 
     installer = TutorVersionInstaller(repository=version_manager)
     installer(version=tutor_version)
+    
+
+@click.command(name="install")
+@click.argument('version', required=True)
+def install(version: str):
+    """Install the given VERSION of tutor in the .tvm directory."""
+    install_tutor_version(version=version)
 
 
 @click.command(name="uninstall")
@@ -261,10 +265,7 @@ def set_switch_from_file(file: str = None) -> None:
     os.chmod(switcher_file, stat.S_IRWXU | stat.S_IRWXG | stat.S_IROTH | stat.S_IXOTH)
 
 
-@click.command(name="use")
-@click.argument('version', required=True)
-def use(version: str):
-    """Configure the path to use VERSION."""
+def use_version(version: str) -> None:
     enabler = TutorVersionEnabler(repository=version_manager)
     try:
         if not version_manager.version_is_installed(version=version):
@@ -275,6 +276,12 @@ def use(version: str):
     except Exception as exc:
         raise click.ClickException(f'The version {version} is not installed you should install it before using it.\n'
                                    f'You could run the command `tvm install {version}` to install it.') from exc
+
+@click.command(name="use")
+@click.argument('version', required=True)
+def use(version: str):
+    """Configure the path to use VERSION."""
+    use_version(version=version)
 
 
 def get_env_by_tutor_version(version):
@@ -371,8 +378,8 @@ def init(name: str = None, version: str = None):
         version = lister(limit=1)[0]
 
     if not current_version:
-        subprocess.run(f"tvm install {version}", shell=True, check=True)
-        subprocess.run(f"tvm use {version}", shell=True, check=True)
+        install_tutor_version(version=version)
+        use_version(version=version)
 
     if name:
         tvm_project_folder = pathlib.Path().resolve() / name
@@ -485,7 +492,6 @@ cli.add_command(use)
 cli.add_command(projects)
 projects.add_command(init)
 cli.add_command(plugins)
-plugins.add_command(list_plugins)
 plugins.add_command(install_plugin)
 plugins.add_command(uninstall_plugin)
 cli.add_command(config)


### PR DESCRIPTION
Currently, the init command needs an installed version to create a new project or one provided by the user in the same command line. This feature is useful when the user specifies no version when running the command. If the user has no installed versions, then _tvm_ will retrieve the latest one, install it, use it, and create the new project. However, if the user has an active global version installed, _tvm_ will use it to create it. 

To try this PR you should follow the two following set of steps:

Under the first scenario, no installed version nor provided in the command:

1. Delete your `.tvm/` folder with `rm -r .tvm/`
2. Run `tvm list` to make sure there is no installed or active version
3. Run `tvm project init <project-name>` 
4. Run `tvm list`

After running the last step, you should see the project with the latest version. Please note that instead of running the last step you can also create a new directory with `mkdir <project-name>`, go to the created folder `cd <project-name>` and simply run `tvm project init`. Nevertheless, both ways should lead to the same result.

Following the second premise, when no version is provided in the command, but there is one installed:

1. Delete your `.tvm/` folder with `rm -r .tvm/`
2. Run `tvm list` to make sure there is no installed or active version
3. Run `tvm install vX.Y.Z` to install any version
6. Run `tvm project init <project-name>` 
7. Run `tvm list`

It is important to highlight that under the second scenario is recommended to install a version different than the last one, just to make sure is not always installing the last one when one version is specified. That's why after the last step you should see the project with the specified version, instead of the last one _if you chose a different version than that_. Here you can also do the variant without stating the project name in the command line, but creating the folder.

Finally, it is also advisable to run the other versions of the `tvm project init` command, such as _tvm_ project init <project-name> <tvm-version>` just to make sure those weren't negatively affected by this new feature, as well as running both variants for each scenario. 