### PR TITLE
fix(DS-291): create a project with a version that is not install

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,44 @@
+<!--
+Please give your pull request a short but descriptive title.
+Use conventional commits to separate and summarize commits logically:
+https://www.conventionalcommits.org/en/v1.0.0/
+
+Use this template as a guide. Omit sections that don't apply.
+
+🙈 Don't be lazy, try to fill out the template well.
+-->
+
+## Description
+
+Describe what this pull request changes, and why. Include implications for people using this change.
+
+Useful information to include:
+- Which user roles will this change impact? Common user roles are "Learner", "Course Author",
+"Developer", and "Operator".
+- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
+- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
+changes.
+
+## Testing instructions
+
+Please provide detailed step-by-step instructions for testing this change.
+
+## Additional information
+
+Include anything else that will help reviewers and consumers understand the change.
+- Does this change depend on other changes elsewhere?
+- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
+- Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
+
+## Checklist for Merge
+
+- [ ] Tested in a remote environment
+- [ ] Updated documentation
+- [ ] Rebased master/main
+- [ ] Squashed commits
+
+<!--
+You can put NA in the checklist if it doesn't apply
+
+- [x] Check that dont't apply / NA
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,7 +32,6 @@ Include anything else that will help reviewers and consumers understand the chan
 
 ## Checklist for Merge
 
-- [ ] Tested in a remote environment
 - [ ] Updated documentation
 - [ ] Rebased master/main
 - [ ] Squashed commits

--- a/docs/source/tvm_quickstart.rst
+++ b/docs/source/tvm_quickstart.rst
@@ -29,55 +29,44 @@ For more information, see the `Tutor requirements <https://docs.tutor.overhang.i
 Step by Step
 -------------
 
-1. Install the latest stable release of TVM.
+#.  Install the latest stable release of TVM.
 
+    .. code-block:: bash
 
-.. code-block:: bash
+        pip install git+https://github.com/eduNEXT/tvm.git
 
-    pip install git+https://github.com/eduNEXT/tvm.git
+#.  Verify the installation.
 
+    .. code-block:: bash
 
-2. Verify the installation.
+        tvm --version
 
-.. code-block:: bash
+#.  Create a new project with TVM.
 
-    tvm --version
+    .. code-block:: bash
 
-3. Install the version of Tutor you want to use.
+        tvm project init <project-name> <tutor-version>
 
-.. code-block:: bash
+        # For example:
+        # tvm project init tvm-test v14.0.0
 
-    tvm install <tutor-version>
+#.  Open the project folder.
 
-    # For example:
-    # tvm install v14.0.0
+    .. code-block:: bash
 
-4. Create a new project with TVM.
+        cd <project-name>
 
-.. code-block:: bash
+#.  Activate the project environment.
 
-    tvm project init <project-name> <tutor-version>
+    .. code-block:: bash
 
-    # For example:
-    # tvm project init tvm-test v14.0.0
+        source .tvm/bin/activate
 
-5. Open the project folder.
+#.  Run your project.
 
-.. code-block:: bash
+    .. code-block:: bash
 
-    cd <project-name>
-
-6. Activate the project environment.
-
-.. code-block:: bash
-
-    source .tvm/bin/activate
-
-7. Run your project.
-
-.. code-block:: bash
-
-    tutor local quickstart
+        tutor local quickstart
 
 
 Next Steps

--- a/docs/source/tvm_topic_guides/environment_manager.rst
+++ b/docs/source/tvm_topic_guides/environment_manager.rst
@@ -23,10 +23,7 @@ Create a Project
     # tvm project init tvm-test v14.0.0
 
 
-.. note:: The `<tutor-version>` parameter is optional. If you don't specify the version, the project will create the project with the version you set previously with `tvm use <tutor-version>` or the latest version.
-
-
-.. warning:: If you are going to specify the `<tutor-version>` , you must have that version in your TVM. If you don't have it, install it with `tvm install <tutor-version>`.
+.. note:: The <tutor-version> parameter is optional. However, if you don't specify the version, the project will be created with the version you set previously with tvm use <tutor-version> or the latest version. If you specify the version, and the version isn't installed, it will be installed.
 
 
 Activate a Project Environment

--- a/docs/source/tvm_tutorials/creating_two_dev_env.rst
+++ b/docs/source/tvm_tutorials/creating_two_dev_env.rst
@@ -6,69 +6,58 @@ At the end of this Tutorial, you will have two different TVM Projects to have tw
 Step by Step
 -------------
 
-1. Install the latest stable release of TVM.
+#.  Install the latest stable release of TVM.
 
+    .. code-block:: bash
 
-.. code-block:: bash
+        pip install git+https://github.com/eduNEXT/tvm.git
 
-    pip install git+https://github.com/eduNEXT/tvm.git
+#.  Verify the installation.
 
+    .. code-block:: bash
 
-2. Verify the installation.
+        tvm --version
 
-.. code-block:: bash
+#.  Create a new project with TVM.
 
-    tvm --version
+    .. code-block:: bash
 
-3. Install the version of Tutor you want to use.
+        tvm project init <project-name> <tutor-version>
 
-.. code-block:: bash
+        # For example:
+        # tvm project init tvm-test v14.0.0
 
-    tvm install <tutor-version>
+#.  Open the project folder.
 
-    # For example:
-    # tvm install v14.0.0
+    .. code-block:: bash
 
-4. Create a new project with TVM.
+        cd <project-name>
 
-.. code-block:: bash
+#.  Activate the project environment.
 
-    tvm project init <project-name> <tutor-version>
+    .. code-block:: bash
 
-    # For example:
-    # tvm project init tvm-test v14.0.0
+        source .tvm/bin/activate
 
-5. Open the project folder.
+#.  Run your project.
 
-.. code-block:: bash
+    .. code-block:: bash
 
-    cd <project-name>
+        tutor dev quickstart
 
-6. Activate the project environment.
+#.  Stop your project.
 
-.. code-block:: bash
+    .. code-block:: bash
 
-    source .tvm/bin/activate
+        tutor dev stop
 
-7. Run your project.
+#.  Deactivate the project environment.
 
-.. code-block:: bash
+    .. code-block:: bash
 
-    tutor dev quickstart
+        tvmoff
 
-8. Stop your project.
-
-.. code-block:: bash
-
-    tutor dev stop
-
-9. Deactivate the project environment.
-
-.. code-block:: bash
-
-    tvmoff
-
-10. Repeat steps 3 to 8 using the project-name and tutor-version you want.
+#.  Repeat steps 3 to 8 using the project-name and tutor-version you want.
 
 .. note::  You can have as many projects as you want, but you can't have two projects with the same name and tutor version.
 

--- a/tvm/cli.py
+++ b/tvm/cli.py
@@ -372,6 +372,7 @@ def projects() -> None:
 def init(name: str = None, version: str = None):
     """Configure a new tvm project in the current path."""
     current_version = version_manager.current_version(f"{TVM_PATH}")
+    local_versions = get_local_versions()
 
     if not version:
         version = current_version
@@ -381,6 +382,10 @@ def init(name: str = None, version: str = None):
         version = lister(limit=1)[0]
 
     if not current_version:
+        install_tutor_version(version=version)
+        use_version(version=version)
+
+    if version not in local_versions:
         install_tutor_version(version=version)
         use_version(version=version)
 


### PR DESCRIPTION
## Description

This PR:
* fix  [BUG] Cant create a project with a version that is not install #52 
* adds PR template

## Testing instructions

1. Install TVM with this branch
```bash
pip install git+https://github.com/eduNEXT/tvm.git@JDB/not_install_version_init
```

2. Run init comman
```bash
tvm project init <project_name> <version_that_isn't_install>
```