### PR TITLE
feat(DS-322): add remove command for remove TVM project

### DIFF
--- a/docs/source/tvm_topic_guides/environment_manager.rst
+++ b/docs/source/tvm_topic_guides/environment_manager.rst
@@ -38,6 +38,9 @@ Remove a Project
     # tvm project remove tvm-test v14.0.0
 
 
+.. note:: You can use the flag --prune to remove the project folder. Ex: `tvm project remove tvm-test v14.0.0 --prune`
+
+
 Activate a Project Environment
 ------------------------------
 

--- a/docs/source/tvm_topic_guides/environment_manager.rst
+++ b/docs/source/tvm_topic_guides/environment_manager.rst
@@ -38,7 +38,7 @@ Remove a Project
     # tvm project remove tvm-test v14.0.0
 
 
-.. note:: You can use the flag --prune to remove the project folder. Ex: `tvm project remove tvm-test v14.0.0 --prune`
+.. note:: You can use the flag --prune to remove all the project folder. Ex: `tvm project remove tvm-test v14.0.0 --prune`
 
 
 Activate a Project Environment

--- a/docs/source/tvm_topic_guides/environment_manager.rst
+++ b/docs/source/tvm_topic_guides/environment_manager.rst
@@ -5,6 +5,7 @@ Index
 ------
 
 - `Create a Project`_
+- `Remove a Project`_
 - `Activate a Project Environment`_
 - `Deactivate a Project Environment`_
 - `List Environments and Projects`_
@@ -24,6 +25,17 @@ Create a Project
 
 
 .. note:: The <tutor-version> parameter is optional. However, if you don't specify the version, the project will be created with the version you set previously with tvm use <tutor-version> or the latest version. If you specify the version, and the version isn't installed, it will be installed.
+
+
+Remove a Project
+-----------------
+
+.. code-block:: bash
+
+    tvm project remove <project-name> <tutor-version>
+
+    # For example:
+    # tvm project remove tvm-test v14.0.0
 
 
 Activate a Project Environment

--- a/docs/source/tvm_topic_guides/environment_manager.rst
+++ b/docs/source/tvm_topic_guides/environment_manager.rst
@@ -5,7 +5,7 @@ Index
 ------
 
 - `Create a Project`_
-- `Remove a Project`_
+- `Remove a Project Environment`_
 - `Activate a Project Environment`_
 - `Deactivate a Project Environment`_
 - `List Environments and Projects`_
@@ -27,18 +27,18 @@ Create a Project
 .. note:: The <tutor-version> parameter is optional. However, if you don't specify the version, the project will be created with the version you set previously with tvm use <tutor-version> or the latest version. If you specify the version, and the version isn't installed, it will be installed.
 
 
-Remove a Project
------------------
+Remove a Project Environment
+----------------------------
 
 .. code-block:: bash
 
-    tvm project remove <project-name> <tutor-version>
+    tvm project remove <tutor-version>@<project-name>
 
     # For example:
-    # tvm project remove tvm-test v14.0.0
+    # tvm project remove v14.0.0@tvm-test
 
 
-.. note:: You can use the flag --prune to remove all the project folder. Ex: `tvm project remove tvm-test v14.0.0 --prune`
+.. note:: You can use the flag --prune to remove all the project folder. Ex: `tvm project remove v14.0.0@tvm-test --prune`
 
 
 Activate a Project Environment

--- a/tests/environment_manager/application/test_tutor_project_remover.py
+++ b/tests/environment_manager/application/test_tutor_project_remover.py
@@ -1,0 +1,20 @@
+import pytest
+
+from tests.environment_manager.infrastructure.environment_manager_in_memory_repository import (
+    EnvironmentManagerInMemoryRepository,
+)
+from tvm.environment_manager.application.tutor_project_remover import (
+    TutorProjectRemover,
+)
+
+
+def test_should_remove_tutor_project():
+    # Given
+    repository = EnvironmentManagerInMemoryRepository()
+
+    # When
+    remove = TutorProjectRemover(repository=repository)
+    remove()
+
+    # Then
+    assert repository.PROJECT_NAME == []

--- a/tests/environment_manager/application/test_tutor_project_remover.py
+++ b/tests/environment_manager/application/test_tutor_project_remover.py
@@ -14,7 +14,7 @@ def test_should_remove_tutor_project():
 
     # When
     remove = TutorProjectRemover(repository=repository)
-    remove()
+    remove(prune=False)
 
     # Then
     assert repository.PROJECT_NAME == []

--- a/tests/environment_manager/infrastructure/environment_manager_in_memory_repository.py
+++ b/tests/environment_manager/infrastructure/environment_manager_in_memory_repository.py
@@ -15,7 +15,7 @@ class EnvironmentManagerInMemoryRepository(EnvironmentManagerRepository):
         else:
             raise Exception('There is already a project initiated.')
 
-    def project_remover(self) -> None:
+    def project_remover(self, prune: bool) -> None:
         """Tutor Project Remove to environment manager."""
         if self.PROJECT_NAME:
             self.PROJECT_NAME.clear()

--- a/tests/environment_manager/infrastructure/environment_manager_in_memory_repository.py
+++ b/tests/environment_manager/infrastructure/environment_manager_in_memory_repository.py
@@ -15,6 +15,13 @@ class EnvironmentManagerInMemoryRepository(EnvironmentManagerRepository):
         else:
             raise Exception('There is already a project initiated.')
 
+    def project_remover(self) -> None:
+        """Tutor Project Remove to environment manager."""
+        if self.PROJECT_NAME:
+            self.PROJECT_NAME.clear()
+        else:
+            raise Exception('There is no project to remove.')
+
 
     def install_plugin(self, options: List) -> None:
         if options:

--- a/tvm/cli.py
+++ b/tvm/cli.py
@@ -16,6 +16,7 @@ from tvm import __version__
 from tvm.environment_manager.application.plugin_installer import PluginInstaller
 from tvm.environment_manager.application.plugin_uninstaller import PluginUninstaller
 from tvm.environment_manager.application.tutor_project_creator import TutorProjectCreator
+from tvm.environment_manager.application.tutor_project_remover import TutorProjectRemover
 from tvm.settings import environment_manager, version_manager
 from tvm.templates.tutor_switcher import TUTOR_SWITCHER_TEMPLATE
 from tvm.version_manager.application.tutor_plugin_installer import TutorPluginInstaller
@@ -408,6 +409,28 @@ def init(name: str = None, version: str = None):
         raise click.UsageError('There is already a project initiated.') from IndexError
 
 
+@click.command(name="remove")
+@click.argument('name', required=True)
+@click.argument('version', required=True)
+def remove(name: str, version: str):
+    """Remove TVM project."""
+    project_name = f"{version}@{name}"
+
+    tvm_project_folder = TVM_PATH / project_name
+
+    if not os.path.exists(tvm_project_folder):
+        raise click.UsageError('There is no project initiated with this name and version.') from IndexError
+
+    if not os.path.exists(tvm_project_folder / 'config.yml'):
+        raise click.UsageError('This project was created in older version or have corrupted files.') from IndexError
+
+    click.confirm(text=f"Are you sure you want to remove the project {project_name}?", abort=True)
+
+    repository = environment_manager(project_path=f"{project_name}")
+    remover = TutorProjectRemover(repository=repository)
+    remover()
+
+
 @click.command(name="install", context_settings={"ignore_unknown_options": True})
 @click.argument('options', nargs=-1, type=click.UNPROCESSED)
 def install_plugin(options):
@@ -499,6 +522,7 @@ cli.add_command(uninstall)
 cli.add_command(use)
 cli.add_command(projects)
 projects.add_command(init)
+projects.add_command(remove)
 cli.add_command(plugins)
 plugins.add_command(install_plugin)
 plugins.add_command(uninstall_plugin)

--- a/tvm/cli.py
+++ b/tvm/cli.py
@@ -412,7 +412,8 @@ def init(name: str = None, version: str = None):
 @click.command(name="remove")
 @click.argument('name', required=True)
 @click.argument('version', required=True)
-def remove(name: str, version: str):
+@click.option('--prune', is_flag=True, help="Remove all files in project folder.")
+def remove(name: str, version: str, prune: bool):
     """Remove TVM project."""
     project_name = f"{version}@{name}"
 
@@ -424,11 +425,17 @@ def remove(name: str, version: str):
     if not os.path.exists(tvm_project_folder / 'config.yml'):
         raise click.UsageError('This project was created in older version or have corrupted files.') from IndexError
 
-    click.confirm(text=f"Are you sure you want to remove the project {project_name}?", abort=True)
+    if prune:
+        click.echo(click.style(f"Removing project {project_name} and all its files in project folder.", fg='red'))
+    else:
+        click.echo(click.style(f"Removing TVM files for project {project_name}.", fg='yellow'))
+        click.echo(click.style("Use --prune to remove all files in project folder.", fg='yellow'))
+
+    click.confirm(text=f"\nAre you sure you want to remove the project {project_name}?", abort=True)
 
     repository = environment_manager(project_path=f"{project_name}")
     remover = TutorProjectRemover(repository=repository)
-    remover()
+    remover(prune=prune)
 
 
 @click.command(name="install", context_settings={"ignore_unknown_options": True})

--- a/tvm/environment_manager/application/tutor_project_remover.py
+++ b/tvm/environment_manager/application/tutor_project_remover.py
@@ -1,0 +1,14 @@
+"""Tutor project initialize."""
+from tvm.environment_manager.domain.environment_manager_repository import EnvironmentManagerRepository
+
+
+class TutorProjectRemover:
+    """Tutor project initialize for environment manager."""
+
+    def __init__(self, repository: EnvironmentManagerRepository) -> None:
+        """init."""
+        self.repository = repository
+
+    def __call__(self) -> None:
+        """call."""
+        self.repository.project_remover()

--- a/tvm/environment_manager/application/tutor_project_remover.py
+++ b/tvm/environment_manager/application/tutor_project_remover.py
@@ -9,6 +9,6 @@ class TutorProjectRemover:
         """init."""
         self.repository = repository
 
-    def __call__(self) -> None:
+    def __call__(self, prune: bool) -> None:
         """call."""
-        self.repository.project_remover()
+        self.repository.project_remover(prune=prune)

--- a/tvm/environment_manager/domain/environment_manager_repository.py
+++ b/tvm/environment_manager/domain/environment_manager_repository.py
@@ -13,6 +13,10 @@ class EnvironmentManagerRepository(ABC):
         """Tutor Project Init to environment manager."""
 
     @abstractmethod
+    def project_remover(self) -> None:
+        """Tutor Project Remove to environment manager."""
+
+    @abstractmethod
     def current_version(self) -> None:
         """Get the project's version."""
 

--- a/tvm/environment_manager/domain/environment_manager_repository.py
+++ b/tvm/environment_manager/domain/environment_manager_repository.py
@@ -13,7 +13,7 @@ class EnvironmentManagerRepository(ABC):
         """Tutor Project Init to environment manager."""
 
     @abstractmethod
-    def project_remover(self) -> None:
+    def project_remover(self, prune: bool) -> None:
         """Tutor Project Remove to environment manager."""
 
     @abstractmethod

--- a/tvm/environment_manager/infrastructure/environment_manager_git_repository.py
+++ b/tvm/environment_manager/infrastructure/environment_manager_git_repository.py
@@ -54,7 +54,9 @@ class EnvironmentManagerGitRepository(EnvironmentManagerRepository):
                     self.logger.echo(f"Project not found in {project}, if you moved it from the original path, you must remove it manually.\n")  # pylint: disable=C0301
 
             self.remove_project(f"{TVM_PATH}/{self.PROJECT_PATH}")
-            self.logger.echo(f"Project {self.PROJECT_PATH} removed from the following paths: {', '.join(deleted_dirs)}")  # pylint: disable=C0301
+            self.logger.echo(f"\nProject {self.PROJECT_PATH} removed from the following paths:")  # pylint: disable=C0301
+            for project in deleted_dirs:
+                self.logger.echo(f"\t{project}")
 
     def remove_project(self, project_path: str):
         """Remove project."""

--- a/tvm/settings.py
+++ b/tvm/settings.py
@@ -9,4 +9,4 @@ version_manager = VersionManagerGitRepository(logger=logger)
 
 def environment_manager(project_path: str) -> EnvironmentManagerGitRepository:
     """Environment manager repository."""
-    return EnvironmentManagerGitRepository(project_path=project_path)
+    return EnvironmentManagerGitRepository(project_path=project_path, logger=logger)


### PR DESCRIPTION
## Description

This PR is to add a command to remove TVM projects.

Also solves https://github.com/eduNEXT/tvm/issues/48

## Jira

[DS-322](https://edunext.atlassian.net/browse/DS-322)

## How to test

1. Install TVM on this branch
2. Create TVM project: `tvm project init test v13.3.1`
3. (Optional) You can init the same project in other path and move or rename it to test the messages.
4. Run `tvm project remove v13.3.1@test` or `tvm project remove v13.3.1@test --prune` 
5. Your .tvm in project folder, and root in ~/.tvm/{version}@{name} should be deleted. (With --prune it should delete all project folder)


- [ ] Test functionality
- [ ] Review changes in files
