### PR TITLE
ci: update the changelog updater step in bumpversion

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -33,7 +33,7 @@ jobs:
           bumpversion --new-version ${{ steps.tag_version.outputs.new_version }} setup.cfg
       - name: Update Changelog
         if: steps.tag_version.outputs.new_version
-        uses: stefanzweifel/changelog-updater-action@v1.6.0
+        uses: stefanzweifel/changelog-updater-action@v1.6.2
         with:
           latest-version: ${{ steps.tag_version.outputs.new_tag }}
           release-notes: ${{ steps.tag_version.outputs.changelog }}


### PR DESCRIPTION
## Description
This PR updates the version of the changelog updater. This correct the error creating the version in tvm.

## Testing

It not need to be tested, is the same error and solution that [eox-tenant PR](https://github.com/eduNEXT/eox-tenant/pull/158)