### PR TITLE
fix: tvm list command error

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -7,3 +7,4 @@ jinja2
 pyyaml
 GitPython
 virtualenv
+packaging

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,19 +12,21 @@ click==8.1.7
     # via -r requirements/base.in
 distlib==0.3.8
     # via virtualenv
-filelock==3.13.3
+filelock==3.14.0
     # via virtualenv
 gitdb==4.0.11
     # via gitpython
 gitpython==3.1.43
     # via -r requirements/base.in
-idna==3.6
+idna==3.7
     # via requests
 jinja2==3.1.3
     # via -r requirements/base.in
 markupsafe==2.1.5
     # via jinja2
-platformdirs==4.2.0
+packaging==24.0
+    # via -r requirements/base.in
+platformdirs==4.2.1
     # via virtualenv
 pyyaml==6.0.1
     # via -r requirements/base.in
@@ -34,5 +36,5 @@ smmap==5.0.1
     # via gitdb
 urllib3==2.2.1
     # via requests
-virtualenv==20.25.1
+virtualenv==20.26.1
     # via -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,7 +16,7 @@ charset-normalizer==3.3.2
     #   requests
 click==8.1.7
     # via -r requirements/base.txt
-coverage==7.4.4
+coverage==7.5.0
     # via -r requirements/dev.in
 dill==0.3.8
     # via pylint
@@ -24,9 +24,9 @@ distlib==0.3.8
     # via
     #   -r requirements/base.txt
     #   virtualenv
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via pytest
-filelock==3.13.3
+filelock==3.14.0
     # via
     #   -r requirements/base.txt
     #   virtualenv
@@ -36,7 +36,7 @@ gitdb==4.0.11
     #   gitpython
 gitpython==3.1.43
     # via -r requirements/base.txt
-idna==3.6
+idna==3.7
     # via
     #   -r requirements/base.txt
     #   requests
@@ -58,16 +58,17 @@ mccabe==0.7.0
     # via pylint
 packaging==24.0
     # via
+    #   -r requirements/base.txt
     #   pudb
     #   pytest
 parso==0.8.4
     # via jedi
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   -r requirements/base.txt
     #   pylint
     #   virtualenv
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 pudb==2024.1
     # via -r requirements/dev.in
@@ -81,7 +82,7 @@ pylint==2.14.5
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/dev.in
-pytest==8.1.1
+pytest==8.2.0
     # via -r requirements/dev.in
 pyyaml==6.0.1
     # via -r requirements/base.txt
@@ -107,13 +108,13 @@ urllib3==2.2.1
     # via
     #   -r requirements/base.txt
     #   requests
-urwid==2.6.10
+urwid==2.6.11
     # via
     #   pudb
     #   urwid-readline
 urwid-readline==0.14
     # via pudb
-virtualenv==20.25.1
+virtualenv==20.26.1
     # via -r requirements/base.txt
 wcwidth==0.2.13
     # via urwid

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -22,7 +22,7 @@ docutils==0.17.1
     #   recommonmark
     #   sphinx
     #   sphinx-panels
-idna==3.6
+idna==3.7
     # via requests
 imagesize==1.4.1
     # via sphinx

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -12,7 +12,7 @@ packaging==24.0
     # via build
 pip-tools==7.4.1
     # via -r requirements/pip-tools.in
-pyproject-hooks==1.0.0
+pyproject-hooks==1.1.0
     # via
     #   build
     #   pip-tools
@@ -20,7 +20,6 @@ tomli==2.0.1
     # via
     #   build
     #   pip-tools
-    #   pyproject-hooks
 wheel==0.43.0
     # via pip-tools
 

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.43.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.0
     # via -r requirements/pip.in
-setuptools==69.2.0
+setuptools==69.5.1
     # via -r requirements/pip.in

--- a/tvm/cli.py
+++ b/tvm/cli.py
@@ -6,7 +6,6 @@ import re
 import stat
 import subprocess
 import sys
-from distutils.version import LooseVersion  # pylint: disable=W0402
 from typing import Optional
 
 import click
@@ -142,7 +141,7 @@ def list_versions(limit: int):
     version_names = lister(limit=limit)
     local_versions = version_manager.local_versions(f"{TVM_PATH}")
     version_names = list(set(version_names + local_versions))
-    version_names = sorted(version_names, reverse=False, key=LooseVersion)
+    version_names = version_manager.sort_tutor_versions(version_names)
     global_active = version_manager.current_version(f"{TVM_PATH}")
     project_version = None
 

--- a/tvm/version_manager/infrastructure/version_manager_git_repository.py
+++ b/tvm/version_manager/infrastructure/version_manager_git_repository.py
@@ -9,6 +9,7 @@ import zipfile
 from typing import List, Optional
 
 import requests
+from packaging.version import parse
 
 from tvm.share.domain.client_logger_repository import ClientLoggerRepository
 from tvm.version_manager.domain.tutor_version import TutorVersion
@@ -223,6 +224,20 @@ class VersionManagerGitRepository(VersionManagerRepository):
 
         self.set_current_info(data=data)
         self.set_switcher()
+
+    def __valid_version_comparer(self, version_name: str):
+        """
+        Turn version name to a valid version object.
+
+        Uses '+' symbol to define local version labels instead "@"
+        https://peps.python.org/pep-0440/#local-version-identifiers
+        """
+        valid_version_name = version_name.replace("@", "+")
+        return parse(valid_version_name)
+
+    def sort_tutor_versions(self, versions: List[TutorVersion]):
+        """Sort tutor versions in ascending order."""
+        return sorted(versions, reverse=False, key=self.__valid_version_comparer)
 
     @staticmethod
     def version_is_installed(version: str) -> bool:


### PR DESCRIPTION
This PR fixes the following bug: https://github.com/eduNEXT/tvm/issues/66

It was removed the dependency `distutils` which is going to be [deprecated](https://peps.python.org/pep-0632/#migration-advice) in future Python releases in favor of [packaging.version](https://packaging.pypa.io/en/latest/version.html). Next, it was necessary to modify the sorter function to take care of the [proper way of implementing local version labels](https://peps.python.org/pep-0440/#local-version-identifiers) and allow packaging.version take the version names properly and create the Version objects that will be compared for sorting 

## Testing instructions
First, remove previous TVM versions running `pip uninstall tutor-version-manager` and `sudo pip uninstall tutor-version-manager` and make sure to use Python version 10

- Install a TVM version without the solution applied `sudo pip install git+https://github.com/eduNEXT/tvm.git`
- Create a project with a numerical name `tvm project init 2024 v17.0.4`
- Run `tvm list` and you'll watch the error
- Uninstall the previous version `sudo pip uninstall tutor-version-manager`
- Install the TVM with the fix `sudo pip install git+https://github.com/eduNEXT/tvm.git@lfc/DS-503`
- Run `tvm list` so you can watch the TVM versions installed properly

[JIRA ISSUE DS-891](https://edunext.atlassian.net/browse/DS-891)