### PR TITLE
fix: use shutil instead of disutils and fix template syntax

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -1,22 +1,13 @@
-
 [MASTER]
 ignore = migrations, templates
 persistent = yes
 
 [MESSAGES CONTROL]
 disable =
-    locally-disabled,
-    locally-enabled,
     too-few-public-methods,
-    bad-builtin,
-    star-args,
-    abstract-class-not-used,
-    abstract-class-little-used,
-    no-init,
     fixme,
     logging-format-interpolation,
     too-many-lines,
-    no-self-use,
     too-many-ancestors,
     too-many-instance-attributes,
     too-few-public-methods,
@@ -29,7 +20,6 @@ disable =
 
 [REPORTS]
 output-format = text
-files-output = no
 reports = no
 evaluation = 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
 
@@ -54,7 +44,6 @@ docstring-min-length = -1
 max-line-length = 120
 ignore-long-lines = ^\s*(# )?<?https?://\S+>?$
 single-line-if-stmt = no
-no-space-check = trailing-comma,dict-separator
 max-module-lines = 1000
 indent-string = '    '
 
@@ -118,11 +107,6 @@ max-public-methods = 20
 
 [IMPORTS]
 deprecated-modules = regsub,TERMIOS,Bastion,rexec
-import-graph =
-ext-import-graph =
-int-import-graph =
 
 [EXCEPTIONS]
 overgeneral-exceptions = Exception
-
-# 1a67033d4799199101eddf63b8ed0bef3e61bda7

--- a/tvm/environment_manager/infrastructure/environment_manager_git_repository.py
+++ b/tvm/environment_manager/infrastructure/environment_manager_git_repository.py
@@ -99,7 +99,6 @@ class EnvironmentManagerGitRepository(EnvironmentManagerRepository):
     def create_project(self, project_name: ProjectName) -> None:
         """Duplicate the version directory and rename it."""
         project_path = os.path.join(TVM_PATH, project_name)
-        
         if not os.path.exists(project_path):
             tutor_version = project_name.split("@")[0]
             tutor_version_folder = os.path.join(TVM_PATH, tutor_version)

--- a/tvm/environment_manager/infrastructure/environment_manager_git_repository.py
+++ b/tvm/environment_manager/infrastructure/environment_manager_git_repository.py
@@ -4,7 +4,6 @@ import os
 import pathlib
 import shutil
 import subprocess
-from distutils.dir_util import copy_tree  # pylint: disable=W0402
 from typing import List
 
 import yaml
@@ -99,25 +98,31 @@ class EnvironmentManagerGitRepository(EnvironmentManagerRepository):
 
     def create_project(self, project_name: ProjectName) -> None:
         """Duplicate the version directory and rename it."""
-        if not os.path.exists(f"{TVM_PATH}/{project_name}"):
+        project_path = os.path.join(TVM_PATH, project_name)
+        
+        if not os.path.exists(project_path):
             tutor_version = project_name.split("@")[0]
-            tutor_version_folder = f"{TVM_PATH}/{tutor_version}"
+            tutor_version_folder = os.path.join(TVM_PATH, tutor_version)
 
-            tvm_project = f"{TVM_PATH}/{project_name}"
-            copy_tree(tutor_version_folder, tvm_project)
-            with open(f"{tvm_project}/config.yml", "w", encoding='utf-8') as f:
-                data = {'project_directories': [f"{self.PROJECT_PATH}"]}
+            shutil.copytree(tutor_version_folder, project_path, dirs_exist_ok=True)
+
+            config_path = os.path.join(project_path, "config.yml")
+            with open(config_path, "w", encoding='utf-8') as f:
+                data = {'project_directories': [self.PROJECT_PATH]}
                 yaml.dump(data, f, default_flow_style=False)
 
-            shutil.rmtree(f"{tvm_project}/venv")
+            venv_path = os.path.join(project_path, "venv")
+            shutil.rmtree(venv_path, ignore_errors=True)
             self.setup_version_virtualenv(project_name)
         else:
-            with open(f"{TVM_PATH}/{project_name}/config.yml", "r+", encoding='utf-8') as f:
+            config_path = os.path.join(project_path, "config.yml")
+            with open(config_path, "r+", encoding='utf-8') as f:
                 data = yaml.load(f, Loader=yaml.FullLoader)
-                data['project_directories'].append(f"{self.PROJECT_PATH}")
-                f.truncate(0)
-                f.seek(0)
-                yaml.dump(data, f, default_flow_style=False)
+                if self.PROJECT_PATH not in data['project_directories']:
+                    data['project_directories'].append(self.PROJECT_PATH)
+                    f.seek(0)
+                    f.truncate()
+                    yaml.dump(data, f, default_flow_style=False)
 
     @staticmethod
     def setup_version_virtualenv(version=None) -> None:

--- a/tvm/templates/tvm_activate.py
+++ b/tvm/templates/tvm_activate.py
@@ -1,7 +1,7 @@
 """Tutor switcher jinja template."""
 from jinja2 import Template
 
-TEMPLATE = '''
+TEMPLATE = r'''
 # This file must be used with "source bin/activate" *from bash*
 # you cannot run it directly
 if [ "${BASH_SOURCE-}" = "$0" ]; then


### PR DESCRIPTION
# Description

This PR is for:

1. fix the error that is appearing with the new python versions: I have changed the code to use shutil instead of distutils and I have refactored it.

` File "/home/edunext/.local/share/pipx/venvs/tutor-version-manager/lib/python3.12/site-packages/tvm/environment_manager/infrastructure/environment_manager_git_repository.py", line 7, in <module>
    from distutils.dir_util import copy_tree  # pylint: disable=W0402
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'distutils'`

2. Fix the SyntaxWarning message:
`/home/edunext/Documents/eduNEXT/tvm/tvm/templates/tvm_activate.py:4: SyntaxWarning: invalid escape sequence '\$'
  TEMPLATE = '''`
